### PR TITLE
ci: pin trivy-action, add gitleaks scanning

### DIFF
--- a/.github/workflows/container-ci.yml
+++ b/.github/workflows/container-ci.yml
@@ -78,7 +78,7 @@ jobs:
         run: docker build -t pgagroal:ci .
 
       - name: Run Trivy filesystem scan
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.31.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -86,7 +86,7 @@ jobs:
           exit-code: '1'
 
       - name: Run Trivy image scan
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.31.0
         with:
           scan-type: 'image'
           image-ref: 'pgagroal:ci'
@@ -95,12 +95,17 @@ jobs:
           ignore-unfixed: true
 
       - name: Run Trivy config scan
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.31.0
         with:
           scan-type: 'config'
           scan-ref: '.'
           severity: 'CRITICAL,HIGH'
           exit-code: '1'
+
+      - name: Run gitleaks secret scan
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
 
   integration-test:
     name: Integration Test


### PR DESCRIPTION
## Summary

- Pin trivy-action from @master to @0.31.0 (supply chain hygiene)
- Add gitleaks secret detection step

Part of Elevarq-wide release protocol standardization. This repo already
had the most mature CI — these are incremental improvements.

## Release gates now enforced in CI

- [x] Correctness: integration tests, resilience tests, startup failure tests
- [x] Lint: hadolint, ShellCheck, Helm lint
- [x] Security: Trivy (fs + image + config), gitleaks
- [ ] Artifact: SBOM generation (TODO — add on release workflow)
- [ ] Supply chain: cosign signing (TODO — add on release workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)