### PR TITLE
Remove stale pgagroal PID file on container start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Container now survives `docker restart` (or any stop/start cycle) after
+  an ungraceful termination. Upstream pgagroal removes its PID file on
+  SIGTERM only; on SIGKILL / OOM / stop-grace expiry the stale
+  `/tmp/pgagroal.<port>.pid` was left on the writable layer and blocked
+  the next start with `pgagroal: PID file ... exists, is there another
+  instance running ?`. The entrypoint now removes any stale PID file
+  before exec'ing pgagroal. Spec: `specifications/docker-restart-resilience/`.
+
+### Added
+
+- `make test-docker-restart` — resilience test that reproduces the
+  SIGKILL-then-start regression and verifies recovery.
+
 ## [1.0.0] - 2026-04-10
 
 First stable public release. Establishes the 1.x release line.

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ HELM_RELEASE := pgagroal
 HELM_CHART   := helm/pgagroal
 NAMESPACE    := pgagroal
 
-.PHONY: build run test test-backend-restart test-concurrent test-pooling test-startup-failure test-invalid-creds test-all test-validation test-refresh clean stop logs helm-lint helm-template helm-install helm-upgrade helm-uninstall refresh refresh-dry-run prepare-release release-check
+.PHONY: build run test test-backend-restart test-docker-restart test-concurrent test-pooling test-startup-failure test-invalid-creds test-all test-validation test-refresh clean stop logs helm-lint helm-template helm-install helm-upgrade helm-uninstall refresh refresh-dry-run prepare-release release-check
 
 # ---------------------------------------------------------------------------
 # Docker
@@ -28,6 +28,10 @@ test:
 test-backend-restart:
 	bash test/resilience/backend-restart-test.sh
 
+## test-docker-restart : Test container recovery after SIGKILL + docker start (stale PID file)
+test-docker-restart:
+	bash test/resilience/docker-restart-test.sh
+
 ## test-concurrent : Test concurrent connections (default 20, override: make test-concurrent CONCURRENCY=50)
 test-concurrent:
 	bash test/resilience/concurrent-connection-test.sh $(CONCURRENCY)
@@ -48,7 +52,7 @@ test-invalid-creds:
 test-validation: test-pooling test-startup-failure test-invalid-creds
 
 ## test-all  : Run every test sequentially
-test-all: test test-backend-restart test-concurrent test-validation
+test-all: test test-backend-restart test-docker-restart test-concurrent test-validation
 
 ## stop      : Stop all services
 stop:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,6 +34,12 @@ fi
 
 echo "Starting pgagroal on ${PGAGROAL_HOST}:${PGAGROAL_PORT} -> ${PG_BACKEND_HOST}:${PG_BACKEND_PORT}"
 
+# Upstream pgagroal does not remove its PID file on SIGKILL/OOM/crash,
+# so a stale /tmp/pgagroal.<port>.pid on the writable layer blocks the
+# next start. Safe because pgagroal is PID 1: if we are starting, no
+# prior pgagroal process can still be alive in this container.
+rm -f "/tmp/pgagroal.${PGAGROAL_PORT}.pid"
+
 # ── Start pgagroal in foreground ──────────────────────────────────────────────
 # pgagroal 2.0.x runs in foreground by default (no -d flag).
 # The -d flag means "daemon mode" and conflicts with log_type=console.

--- a/specifications/docker-restart-resilience/acceptance-cases.md
+++ b/specifications/docker-restart-resilience/acceptance-cases.md
@@ -1,0 +1,59 @@
+# Acceptance Cases: Container Survives `docker restart`
+
+Derived from `spec.md`. Each case maps to behaviors, rules, or
+invariants in the specification.
+
+## AC-01: Fresh start — baseline
+
+**Spec refs**: B1, I3
+
+**Given**: a freshly built image, no prior container on the host
+**When**: `docker run -d --name pgagroal-test ...`
+**Then**:
+- Container reaches `healthy` within the configured healthcheck window
+- `/tmp/pgagroal.6432.pid` exists inside the running container (pgagroal
+  created it)
+
+## AC-02: Restart after ungraceful termination — stale PID file present
+
+**Spec refs**: B2, R1, R2, I1
+
+**Given**: a container that has been running, then terminated via
+SIGKILL (simulating stop-grace expiry, OOM, or host crash), with a
+stale `/tmp/pgagroal.6432.pid` left behind on the writable layer.
+Confirmed stale by committing the stopped container to an image and
+inspecting `/tmp`.
+**When**: `docker start <container>`
+**Then**:
+- Container returns to `healthy` within the healthcheck window
+- A SQL query via pgagroal succeeds (end-to-end proof the restart worked)
+- pgagroal logs do NOT contain `PID file ... exists, is there another instance running`
+- Exit code 0 from the test harness
+
+**This is the regression test for the defect described in the spec.**
+Without the entrypoint guard, `docker start` fails with the PID-file
+conflict message and the container becomes unhealthy (exit 1).
+
+## AC-03: Clean shutdown on SIGTERM + restart
+
+**Spec refs**: B3, B4
+
+**Given**: a running, healthy container
+**When**: `docker stop <container>` (default SIGTERM within grace),
+followed by `docker start <container>`
+**Then**:
+- First stop: container exits within the grace period, exit code 0
+- Second start: container returns to `healthy`
+- Entrypoint guard executes as a no-op (PID file already absent)
+
+## AC-04: Unix socket files are not touched by the entrypoint guard
+
+**Spec refs**: R3
+
+**Given**: the entrypoint guard removes the stale PID file
+**When**: inspecting the `rm` pattern in `entrypoint.sh`
+**Then**:
+- The command targets exactly `/tmp/pgagroal.${PGAGROAL_PORT}.pid`
+- The command does NOT use a glob that would also match socket files
+  (e.g. `/tmp/pgagroal.*`, `/tmp/*`)
+- Verified by inspection; no runtime test required

--- a/specifications/docker-restart-resilience/spec.md
+++ b/specifications/docker-restart-resilience/spec.md
@@ -1,0 +1,101 @@
+# Specification: Container Survives `docker restart`
+
+Status: ACTIVE
+
+## Purpose
+
+Ensure the `pgagroal` container image tolerates a full stop/start cycle
+(`docker restart`, Kubernetes pod restart on the same node with an
+ephemeral writable layer retained, systemd service restart, etc.)
+without operator intervention.
+
+The immediate trigger is a defect observed in upstream `pgagroal`:
+the PID file (`/tmp/pgagroal.<port>.pid`) is only removed during the
+graceful SIGTERM shutdown path. When the process is terminated by
+SIGKILL — including the Docker stop→kill escalation after grace
+expiry, OOM kills, host crashes, and `docker kill` — no cleanup runs
+and the PID file is left behind. Because the container image keeps
+the PID file on the writable filesystem layer, the stale file
+survives a subsequent `docker start` and pgagroal refuses to start:
+
+```
+pgagroal: PID file </tmp//pgagroal.6433.pid> exists, is there another instance running ?
+```
+
+The container then exits with status 1 and the healthcheck fails.
+
+This specification pins down the invariant the container is expected
+to guarantee, independent of upstream behavior.
+
+## Scope
+
+Applies to the `pgagroal` container image produced by this repository
+(`Dockerfile`, `entrypoint.sh`, configuration templates).
+
+Does NOT govern upstream `pgagroal` source behavior. Upstream fixes
+are tracked separately; the container guarantee must hold whether or
+not upstream ships a fix.
+
+## Interfaces
+
+No new inputs, outputs, or CLI arguments are introduced. The guarantee
+is a behavioral invariant of the image.
+
+Relevant existing inputs:
+
+| Input | Effect on PID file location |
+|---|---|
+| `PGAGROAL_PORT` env var (default `6432`) | PID file path is `/tmp/pgagroal.${PGAGROAL_PORT}.pid` |
+
+## Behaviors
+
+| ID | Given | When | Then |
+|---|---|---|---|
+| B1 | Container started from a fresh filesystem | Container is started | pgagroal starts, becomes healthy |
+| B2 | Container was terminated ungracefully (SIGKILL, OOM, host crash, stop-grace expiry) leaving `/tmp/pgagroal.<port>.pid` on the writable layer | Container is started again (`docker start` or `docker restart`) | pgagroal starts, becomes healthy |
+| B3 | Container is running | SIGTERM delivered to PID 1 | Container exits with status 0 within the platform's stop grace period (upstream already handles this; covered as a baseline invariant) |
+| B4 | Container previously shut down cleanly via SIGTERM (PID file already removed by upstream) | Container is started again | pgagroal starts, becomes healthy (entrypoint guard is a no-op) |
+
+## Rules
+
+| ID | Rule |
+|---|---|
+| R1 | Before `exec pgagroal`, the entrypoint MUST remove any pre-existing PID file at `/tmp/pgagroal.${PGAGROAL_PORT}.pid`. |
+| R2 | The removal MUST be idempotent — absence of the file is not an error. |
+| R3 | The entrypoint MUST NOT remove any other file under `/tmp/` (the Unix socket directory is also `/tmp/`). |
+
+## Invariants
+
+| ID | Invariant |
+|---|---|
+| I1 | A stale PID file never blocks container startup. |
+| I2 | The fix is self-contained in the image. Consumers do not need to mount a tmpfs, add a volume, or change their `docker run` / compose / Helm invocations. |
+| I3 | The entrypoint's behavior on first start (no stale PID file) is unchanged. |
+
+## Failure conditions
+
+| Trigger | System response |
+|---|---|
+| PID file path is not writable (should not happen — `/tmp/` is always writable) | `rm -f` fails silently; pgagroal start may then fail. Treated as an environment bug, not a spec violation. |
+| Another process is listening on `PGAGROAL_PORT` inside the container namespace | pgagroal exits with its normal bind error. Out of scope for this spec. |
+
+## Constraints
+
+- No dependency added beyond `rm` (coreutils) already present in the base image.
+- No change to image size, base image, or exposed ports.
+- No change to configuration template defaults.
+
+## Non-goals
+
+- Fixing upstream pgagroal's SIGTERM handler. That is pursued separately and, once merged and pinned here, the container-side guard becomes redundant but is retained as defense-in-depth.
+- Guaranteeing behavior across filesystem corruption, OOM kills mid-write, or `SIGKILL` followed by writable-layer loss — those are orthogonal failure modes.
+- Preventing startup when a *live* pgagroal process still holds the port (this is a misconfiguration, not a restart scenario).
+
+## Traceability
+
+| Spec element | Acceptance case |
+|---|---|
+| B1, I3 | AC-01 |
+| B2, R1, R2, I1 | AC-02 |
+| B3, B4 | AC-03 |
+| R3 | AC-04 |

--- a/test/resilience/docker-restart-test.sh
+++ b/test/resilience/docker-restart-test.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+#
+# Resilience test: verify the pgagroal container survives restart after
+# an ungraceful termination (SIGKILL / OOM / stop-grace expiry).
+#
+# Upstream pgagroal removes its PID file on SIGTERM but not on SIGKILL.
+# Because the image keeps the PID file on the writable layer
+# (/tmp/pgagroal.<port>.pid), a stale file survives and blocks the next
+# start with:
+#   pgagroal: PID file </tmp//pgagroal.<port>.pid> exists, is there
+#             another instance running ?
+# The entrypoint removes any stale PID file before exec'ing pgagroal.
+#
+# Spec:  specifications/docker-restart-resilience/spec.md
+# Cases: AC-01, AC-02, AC-03
+#
+# Exit codes:
+#   0  container restarts cleanly and recovers to healthy
+#   1  restart failed (container unhealthy, query failed, or unclean stop)
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../" && pwd)"
+cd "${SCRIPT_DIR}"
+
+IMAGE="pgagroal:test"
+NET="pgagroal-restart-net"
+PG="pgagroal-restart-pg"
+POOLER="pgagroal-restart-pool"
+PGAGROAL_PORT="6432"
+HEALTHY_TIMEOUT=60
+DBG_IMAGE="pgagroal-restart-dbg:stopped"
+
+cleanup() {
+    echo "--- Cleaning up ---"
+    docker rm -f "${POOLER}" "${PG}" 2>/dev/null || true
+    docker network rm "${NET}" 2>/dev/null || true
+    docker rmi "${DBG_IMAGE}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+wait_healthy() {
+    local name="$1"
+    local limit="$2"
+    local elapsed=0
+    echo "  waiting for ${name} healthy (max ${limit}s)..."
+    until [ "$(docker inspect --format='{{.State.Health.Status}}' "${name}" 2>/dev/null || echo none)" = "healthy" ]; do
+        if [ "${elapsed}" -ge "${limit}" ]; then
+            echo "FAIL: ${name} not healthy within ${limit}s"
+            docker logs --tail=60 "${name}" || true
+            return 1
+        fi
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+    echo "  ${name} healthy after ${elapsed}s"
+}
+
+run_query() {
+    docker run --rm --network "${NET}" \
+        -e PGPASSWORD=testpass \
+        postgres:17.4-bookworm \
+        psql -h "${POOLER}" -p "${PGAGROAL_PORT}" \
+             -U testuser -d testdb -tA \
+             -c "SELECT 'ok' AS status;" 2>/dev/null
+}
+
+echo "=== Docker Restart Resilience Test ==="
+
+echo "--- Step 1: Build image ---"
+docker build -t "${IMAGE}" .
+
+echo "--- Step 2: Create network ---"
+docker network create "${NET}" >/dev/null
+
+echo "--- Step 3: Start postgres ---"
+docker run -d --name "${PG}" --network "${NET}" \
+    -e POSTGRES_USER=testuser \
+    -e POSTGRES_PASSWORD=testpass \
+    -e POSTGRES_DB=testdb \
+    postgres:17.4-bookworm >/dev/null
+
+elapsed=0
+until docker exec "${PG}" pg_isready -U testuser -d testdb >/dev/null 2>&1; do
+    if [ "${elapsed}" -ge 60 ]; then
+        echo "FAIL: postgres did not become ready"
+        exit 1
+    fi
+    sleep 2
+    elapsed=$((elapsed + 2))
+done
+echo "  postgres ready"
+
+echo "--- Step 4: Start pgagroal (first run) — AC-01 ---"
+docker run -d --name "${POOLER}" --network "${NET}" \
+    -e PG_BACKEND_HOST="${PG}" \
+    -e PG_BACKEND_PORT=5432 \
+    -e PGAGROAL_PORT="${PGAGROAL_PORT}" \
+    "${IMAGE}" >/dev/null
+
+wait_healthy "${POOLER}" "${HEALTHY_TIMEOUT}"
+
+if ! docker exec "${POOLER}" test -f "/tmp/pgagroal.${PGAGROAL_PORT}.pid"; then
+    echo "FAIL: expected /tmp/pgagroal.${PGAGROAL_PORT}.pid to exist on running container"
+    exit 1
+fi
+echo "  PID file present"
+
+result=$(run_query)
+if [ "${result}" != "ok" ]; then
+    echo "FAIL: baseline query returned '${result}' instead of 'ok'"
+    exit 1
+fi
+echo "  baseline query OK"
+
+echo "--- Step 5: SIGKILL (simulates stop-grace expiry / OOM / crash) ---"
+docker kill --signal=SIGKILL "${POOLER}" >/dev/null
+# Wait briefly for the docker engine to settle into 'exited'.
+for _ in 1 2 3 4 5; do
+    status=$(docker inspect --format='{{.State.Status}}' "${POOLER}" 2>/dev/null || echo none)
+    [ "${status}" = "exited" ] && break
+    sleep 1
+done
+echo "  container exited"
+
+echo "--- Step 6: Confirm stale PID file survives on writable layer ---"
+docker commit "${POOLER}" "${DBG_IMAGE}" >/dev/null
+if ! docker run --rm --entrypoint test "${DBG_IMAGE}" -f "/tmp/pgagroal.${PGAGROAL_PORT}.pid"; then
+    echo "FAIL: expected stale PID file on writable layer — cannot exercise the bug"
+    exit 1
+fi
+echo "  stale PID file confirmed on writable layer"
+
+echo "--- Step 7: docker start — AC-02 (the regression) ---"
+docker start "${POOLER}" >/dev/null
+if ! wait_healthy "${POOLER}" "${HEALTHY_TIMEOUT}"; then
+    echo "FAIL: container did not recover after SIGKILL+start (stale PID blocked startup)"
+    exit 1
+fi
+
+if docker logs "${POOLER}" 2>&1 | grep -q "PID file .* exists, is there another instance running"; then
+    echo "FAIL: pgagroal reported stale PID file conflict after restart"
+    docker logs --tail=40 "${POOLER}"
+    exit 1
+fi
+
+result=$(run_query)
+if [ "${result}" != "ok" ]; then
+    echo "FAIL: post-restart query returned '${result}' instead of 'ok'"
+    docker logs --tail=40 "${POOLER}"
+    exit 1
+fi
+echo "  post-restart query OK"
+
+echo "--- Step 8: Graceful SIGTERM + start — AC-03 ---"
+start_ts=$(date +%s)
+docker stop --timeout 10 "${POOLER}" >/dev/null
+stop_ts=$(date +%s)
+elapsed=$((stop_ts - start_ts))
+exit_code=$(docker inspect --format='{{.State.ExitCode}}' "${POOLER}")
+if [ "${exit_code}" != "0" ]; then
+    echo "FAIL: graceful stop produced exit ${exit_code} (expected 0)"
+    exit 1
+fi
+if [ "${elapsed}" -ge 10 ]; then
+    echo "FAIL: graceful stop took ${elapsed}s (>= 10s grace — likely SIGKILLed)"
+    exit 1
+fi
+echo "  clean SIGTERM shutdown (exit 0, ${elapsed}s)"
+
+docker start "${POOLER}" >/dev/null
+wait_healthy "${POOLER}" "${HEALTHY_TIMEOUT}"
+result=$(run_query)
+if [ "${result}" != "ok" ]; then
+    echo "FAIL: query after graceful-restart returned '${result}'"
+    exit 1
+fi
+echo "  graceful-restart query OK"
+
+echo ""
+echo "=== DOCKER RESTART TEST PASSED ==="


### PR DESCRIPTION
## Summary

- `docker restart` (and any stop→start after SIGKILL / OOM / stop-grace expiry) currently leaves the container stuck unhealthy because a stale `/tmp/pgagroal.<port>.pid` blocks pgagroal's next start.
- Root cause: upstream pgagroal cleans up the PID file only on the SIGTERM path; SIGKILL can't be caught, so the file survives on the writable layer. A proper startup-side fix (stale-PID detection by liveness check) belongs upstream, but the container-side guard is cleaner for this image because pgagroal runs as PID 1 — when the entrypoint runs, no prior pgagroal in this container is still alive.
- Fix: `entrypoint.sh` now runs `rm -f /tmp/pgagroal.${PGAGROAL_PORT}.pid` immediately before `exec pgagroal`. Idempotent; targets only the PID file (Unix sockets share `/tmp` and must not be touched).
- Added STDD spec (`specifications/docker-restart-resilience/`) and resilience test (`test/resilience/docker-restart-test.sh`, wired in as `make test-docker-restart`) that reproduces the regression via SIGKILL + `docker commit` (to prove the stale PID file survives) + `docker start`.

## Reproduction (before this PR)

```
$ docker run -d --name p ... elevarq/pgagroal:latest
$ docker kill --signal=SIGKILL p      # or OOM, or stop-grace expiry
$ docker start p
$ docker logs p
pgagroal: PID file </tmp//pgagroal.6432.pid> exists, is there another instance running ?
```

Red→green verified locally: test fails on `main`, passes on this branch.

## Test plan

- [x] `make test-docker-restart` — passes post-fix, fails pre-fix (confirmed)
- [x] `make test-all` — full suite in CI
- [x] Review spec (`specifications/docker-restart-resilience/spec.md`) — confirm behaviors B1–B4 and invariants I1–I3 match intended guarantee
- [x] Confirm no regression on `make test-backend-restart` and `make test`

## Follow-ups (not in this PR)

- File upstream issue: startup-side stale-PID detection (liveness check) in pgagroal — the real gap. Shutdown-side cleanup is unreliable by nature (SIGKILL).
- Container-side guard stays regardless; it's correct for PID-1 semantics.