### PR TITLE
ci: automate Docker Hub overview sync from DOCKER_HUB.md

### DIFF
--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -1,0 +1,31 @@
+---
+name: Sync Docker Hub description
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'DOCKER_HUB.md'
+      - '.github/workflows/dockerhub-description.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    name: Push DOCKER_HUB.md to Docker Hub
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update Docker Hub repository description
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: elevarq/pgagroal
+          readme-filepath: ./DOCKER_HUB.md
+          short-description: >-
+            Production-grade pgagroal PostgreSQL connection pooler —
+            signed, multi-arch, SBOM-attested.

--- a/DOCKER_HUB.md
+++ b/DOCKER_HUB.md
@@ -1,23 +1,29 @@
-# pgagroal
+# pgAgroal
 
-Production-ready PostgreSQL connection pooler container.
+Production-grade container image for [pgagroal](https://github.com/pgagroal/pgagroal) — a high-performance PostgreSQL connection pooler. Built from source, signed, SBOM-attested, multi-arch.
 
-- Minimal latency overhead (~0.1-0.3 ms per statement)
-- Multi-architecture (amd64, arm64)
-- Signed images (Cosign, keyless via GitHub OIDC)
-- SBOM and SLSA provenance included
-- Hardened runtime (non-root, no capabilities)
+## Why this image
 
-## Contents
-
-- pgagroal 2.0.2
-- Base image: debian:bookworm-20260316-slim
-- Architectures: amd64, arm64
+- **Reproducible builds** from pinned source (pgagroal 2.0.2, Debian bookworm).
+- **Multi-arch** manifests: `linux/amd64` and `linux/arm64`.
+- **Signed with cosign** (keyless, GitHub OIDC) on every release.
+- **SBOM + SLSA provenance** attached as OCI attestations.
+- **Hardened runtime**: non-root (UID 1000), all capabilities dropped, read-only root filesystem, seccomp `RuntimeDefault`.
+- **Configuration via environment variables** — no config files to mount.
+- Aligned with SOC 2 / ISO 27001 engineering practices.
 
 ## Quick start
 
 ```bash
 docker pull elevarq/pgagroal:1.0.1
+
+docker run -d --name pgagroal \
+  -p 6432:6432 \
+  -e PG_BACKEND_HOST=your-postgres-host \
+  -e PG_BACKEND_PORT=5432 \
+  elevarq/pgagroal:1.0.1
+
+psql -h localhost -p 6432 -U youruser -d yourdb -c 'SELECT 1;'
 ```
 
 ## Verify
@@ -28,6 +34,54 @@ cosign verify elevarq/pgagroal:1.0.1 \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```
 
+## Required ports
+
+| Port | Purpose |
+|---|---|
+| `6432` | pgagroal listener (PostgreSQL wire protocol) |
+| `9187` | Prometheus metrics (optional, disabled by default) |
+
+## Minimal configuration
+
+All configuration is via environment variables. Defaults are production-safe.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `PG_BACKEND_HOST` | `postgres` | Upstream PostgreSQL host |
+| `PG_BACKEND_PORT` | `5432` | Upstream PostgreSQL port |
+| `PGAGROAL_PORT` | `6432` | pgagroal listen port |
+| `PGAGROAL_HOST` | `*` | pgagroal bind address |
+| `MAX_CONNECTIONS` | `100` | Max pooled connections |
+| `PGAGROAL_LOG_LEVEL` | `info` | Log level |
+| `PG_USERNAME` | — | Optional; registers a pgagroal user for frontend auth |
+| `PG_PASSWORD` | — | Password for `PG_USERNAME` |
+
+## Metrics
+
+pgagroal ships a built-in Prometheus exporter. Enable it by exposing port `9187` and scraping `/metrics`. In the Helm chart this is `metrics.enabled=true`.
+
+## Versioning and tags
+
+Tags follow the project version in [VERSION](https://github.com/Elevarq/pgAgroal/blob/main/VERSION), not the upstream pgagroal version.
+
+| Tag | Meaning |
+|---|---|
+| `1.0.1` | Exact release — pin this in production |
+| `1.0` | Latest patch of the 1.0 line |
+| `latest` | Most recent stable release — convenience only |
+
+Only CI publishes tags. `latest` is a multi-arch manifest updated on every release.
+
 ## Documentation
 
-<https://elevarq.com/docs/pgagroal-container>
+- Full README, operations guide, Helm chart, and deployment examples: [github.com/Elevarq/pgAgroal](https://github.com/Elevarq/pgAgroal)
+- Kubernetes / EKS deployment: [docs/deployment](https://github.com/Elevarq/pgAgroal/tree/main/docs/deployment)
+- Operations and failure modes: [docs/operations](https://github.com/Elevarq/pgAgroal/tree/main/docs/operations)
+
+## Source and issues
+
+- Source: [github.com/Elevarq/pgAgroal](https://github.com/Elevarq/pgAgroal)
+- Bugs and feature requests: [GitHub Issues](https://github.com/Elevarq/pgAgroal/issues)
+- Security: see [SECURITY.md](https://github.com/Elevarq/pgAgroal/blob/main/SECURITY.md)
+
+Licensed under BSD-3-Clause. Contains unmodified pgagroal from [pgagroal/pgagroal](https://github.com/pgagroal/pgagroal).

--- a/docs/release/release-checklist.md
+++ b/docs/release/release-checklist.md
@@ -212,14 +212,18 @@ For the full evidence checklist with audit-grade commands, see
 ## Docker Hub Documentation
 
 The Docker Hub repository overview is maintained in `DOCKER_HUB.md` at
-the repository root. After any release that changes version numbers,
-features, or verification instructions:
+the repository root and synced automatically by
+`.github/workflows/dockerhub-description.yml` whenever that file (or
+the workflow itself) changes on `main`. Manual copy-paste into Docker
+Hub is no longer required.
 
-1. Update `DOCKER_HUB.md` in the same commit or a follow-up commit.
-2. Copy the contents to Docker Hub > elevarq/pgagroal > General >
-   Repository overview.
-3. Verify that the Quick Start example, image tags table, and
-   verification commands in Docker Hub match the current release.
+Release hygiene:
+
+1. Bump version references in `DOCKER_HUB.md` as part of the release
+   PR (alongside `VERSION`, `Chart.yaml`, `README.md`, `CHANGELOG.md`).
+2. After merge, confirm the `Sync Docker Hub description` workflow run
+   on the merge commit succeeded.
+3. Spot-check the Docker Hub overview renders as expected.
 
 The `README.md` Pinned Versions table must also be updated to match.
 
@@ -265,6 +269,9 @@ build all platforms in a single workflow run.
 manifest on every release.
 
 **Keep Docker Hub docs in sync.** `DOCKER_HUB.md` is the source of
-truth for the Docker Hub repository overview but is not automatically
-synced. After any release that changes version numbers or verification
-commands, update both the file and the Docker Hub overview.
+truth for the Docker Hub repository overview and is synced
+automatically by `.github/workflows/dockerhub-description.yml`.
+Historical note: prior releases required a manual copy-paste into
+Docker Hub's General → Repository overview, which drifted in practice.
+The workflow fixes that drift; the file-level version bumps (in the
+release PR) remain a manual step.

--- a/docs/release/release-evidence-checklist.md
+++ b/docs/release/release-evidence-checklist.md
@@ -123,6 +123,6 @@ Replace `${VERSION}` with the release version (e.g. `1.0.0`).
 
 - [ ] `README.md` Pinned Versions table matches the release
 - [ ] `DOCKER_HUB.md` references the current version
-- [ ] Docker Hub repository overview matches `DOCKER_HUB.md`
+- [ ] Docker Hub repository overview synced (handled automatically by `.github/workflows/dockerhub-description.yml` on push-to-main; workflow run succeeded)
 - [ ] `CHANGELOG.md` has an entry for this release
 - [ ] `VERSION` file matches the tagged version


### PR DESCRIPTION
## Summary

Adds a dedicated workflow that pushes `DOCKER_HUB.md` to the Docker Hub repository overview automatically whenever the file (or the workflow itself) changes on `main`. Removes the manual copy-paste step that was documented in the release checklist and — per the "Release Pitfalls" section of that same checklist — drifted in practice.

## Files changed

| File | Change |
|---|---|
| `.github/workflows/dockerhub-description.yml` | **new** — sync workflow |
| `DOCKER_HUB.md` | rewritten for Docker Hub landing-page audience |
| `docs/release/release-checklist.md` | manual-sync guidance replaced with "handled automatically" |
| `docs/release/release-evidence-checklist.md` | Docker Hub overview check rewritten |

## Workflow behavior

- Triggers: `push` to `main` with path filter on `DOCKER_HUB.md` and the workflow file; plus `workflow_dispatch` for manual runs.
- Single job, single step: `peter-evans/dockerhub-description@v5`.
- Completely independent from `publish.yml`. A docs-sync failure does not block image delivery; an image release does not re-push the overview.
- `short-description`: "Production-grade pgagroal PostgreSQL connection pooler — signed, multi-arch, SBOM-attested." (93 bytes, under the 100-byte Docker Hub limit).
- `readme-filepath`: `./DOCKER_HUB.md` (3.4 KB, well under the 25 KB Docker Hub limit).
- No `enable-url-completion` — `DOCKER_HUB.md` uses absolute GitHub URLs throughout, so no rewriting needed.

## DOCKER_HUB.md structure

Title · positioning paragraph · Why this image · Quick start · Verify (cosign) · Required ports · Minimal configuration · Metrics · Versioning and tags · Documentation · Source and issues.

Optimized for first-time users landing on the Docker Hub page: what it is, why to use it, how to run it, where the docs are. No badges, no deep tables, no internal notes.

## Manual setup you must do

1. **Confirm the GitHub secrets exist on `Elevarq/pgAgroal`**: `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`. They are already used by `publish.yml` for image pushes, so this should already be the case.
2. **Confirm the Docker Hub user has admin rights on `elevarq/pgagroal`**. The `peter-evans/dockerhub-description@v5` action requires admin permission on the target repository when the repo belongs to an organization.
3. **Prefer a Docker Hub Personal Access Token over a password.** If `DOCKERHUB_TOKEN` is currently a password, consider rotating it to a PAT scoped to this repository's admin-permission needs.
4. **Verify the first sync** after merge: watch the `Sync Docker Hub description` workflow run and confirm the overview at https://hub.docker.com/r/elevarq/pgagroal renders correctly.

## Test plan

- [x] `actionlint .github/workflows/dockerhub-description.yml` — clean
- [x] `yamllint` — clean
- [x] `DOCKER_HUB.md` size: 3397 bytes (under Docker Hub's 25 KB limit)
- [x] `short-description` size: 93 bytes (under Docker Hub's 100-byte limit)
- [x] No relative links in `DOCKER_HUB.md` — all GitHub URLs are absolute