### PR TITLE
ci: automate upstream tracking (Dependabot + pgagroal release watcher)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+---
+# Dependabot configuration.
+#
+# - GitHub Actions: version bumps for all `uses:` in .github/workflows/
+# - Docker: base image pins in Dockerfile (debian:bookworm-*-slim).
+#
+# pgagroal upstream version is NOT tracked here — it's built from source
+# (not pulled as an image). See .github/workflows/refresh-pgagroal-upstream.yml
+# for pgagroal version tracking.
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - automation
+      - dependencies
+    commit-message:
+      prefix: "ci"
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    labels:
+      - automation
+      - dependencies
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/refresh-pgagroal-upstream.yml
+++ b/.github/workflows/refresh-pgagroal-upstream.yml
@@ -1,0 +1,103 @@
+---
+# Weekly check against pgagroal/pgagroal for a new stable release.
+# If the latest upstream stable (x.y.z) differs from what this repo pins,
+# opens a PR with the bump. Review and merge manually — cutting a project
+# release tag (v1.x.y) after merge stays a human decision.
+#
+# PAT note: PRs created with the default GITHUB_TOKEN do not trigger CI
+# workflows (GitHub security restriction). Configure a fine-grained PAT
+# with `contents: write` and `pull-requests: write` on this repo and
+# store it as the repository secret REFRESH_BOT_TOKEN to get CI running
+# automatically on the opened PR. Without it, close+reopen the PR to
+# force CI.
+
+name: Refresh pgagroal upstream
+
+on:
+  schedule:
+    - cron: '0 7 * * 1'   # Mondays 07:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-and-pr:
+    name: Check pgagroal upstream, open PR if newer
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve latest pgagroal stable release
+        id: upstream
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          latest=$(gh api repos/pgagroal/pgagroal/releases/latest --jq '.tag_name')
+          version="${latest#v}"
+          if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Skipping non-stable release: ${latest}"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Upstream latest stable: ${version}"
+
+      - name: Read current pgagroal version
+        id: current
+        run: |
+          current=$(sed -n 's/^ARG PGAGROAL_VERSION=\([0-9.]*\)/\1/p' Dockerfile)
+          echo "version=${current}" >> "$GITHUB_OUTPUT"
+          echo "Current pinned version: ${current}"
+
+      - name: Decide whether to refresh
+        id: decide
+        if: steps.upstream.outputs.skip != 'true'
+        run: |
+          if [[ "${{ steps.upstream.outputs.version }}" == "${{ steps.current.outputs.version }}" ]]; then
+            echo "Already on pgagroal ${{ steps.current.outputs.version }}. Nothing to do."
+            echo "refresh=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "refresh=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run refresh script
+        if: steps.decide.outputs.refresh == 'true'
+        run: |
+          bash scripts/refresh-pgagroal.sh \
+            --version ${{ steps.upstream.outputs.version }} \
+            --skip-tests \
+            --update-changelog
+
+      - name: Open pull request
+        if: steps.decide.outputs.refresh == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.REFRESH_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          branch: automation/refresh-pgagroal-${{ steps.upstream.outputs.version }}
+          delete-branch: true
+          commit-message: |
+            chore: refresh pgagroal upstream to ${{ steps.upstream.outputs.version }}
+
+            Automated by .github/workflows/refresh-pgagroal-upstream.yml
+          title: "chore: refresh pgagroal upstream to ${{ steps.upstream.outputs.version }}"
+          labels: |
+            automation
+            upstream-refresh
+          body: |
+            Automated upstream refresh.
+
+            **pgagroal**: `${{ steps.current.outputs.version }}` → `${{ steps.upstream.outputs.version }}`
+
+            Upstream release notes: https://github.com/pgagroal/pgagroal/releases/tag/${{ steps.upstream.outputs.version }}
+
+            ## Review checklist
+
+            - Read upstream release notes for behavioral changes, deprecations, or new config keys.
+            - Confirm CI (lint, tests, Trivy, gitleaks) is green on this PR.
+            - After merge, decide whether this warrants a `v1.x.y` project release tag. The tag is not cut automatically.
+
+            ## CI trigger note
+
+            If this PR shows no CI checks running, close and immediately reopen it (or push an empty commit). PRs created with the default `GITHUB_TOKEN` cannot fire other workflows — this is a GitHub security feature. Configure a PAT as `REFRESH_BOT_TOKEN` to remove the friction; the workflow picks it up automatically.


### PR DESCRIPTION
## Summary

Closes the 'what fires when upstream changes' gap. Two small, independent pieces:

### 1. Dependabot (`.github/dependabot.yml`)

- **github-actions** ecosystem: weekly PRs for action version bumps.
- **docker** ecosystem: weekly PRs for the Debian base image pin (tracks `FROM debian:${DEBIAN_VERSION}` in the Dockerfile).
- pgagroal upstream is intentionally **not** tracked by Dependabot — it's built from source, not pulled as an image, so the Docker ecosystem has nothing to see. Handled by the release watcher below.

### 2. pgagroal release watcher (`.github/workflows/refresh-pgagroal-upstream.yml`)

- Weekly cron (Mon 07:00 UTC) + `workflow_dispatch` for manual kick-off.
- Queries `pgagroal/pgagroal` latest release via `gh` CLI, filters to stable `x.y.z` (pre-releases ignored), compares with `ARG PGAGROAL_VERSION` in `Dockerfile`.
- If newer: runs `scripts/refresh-pgagroal.sh --skip-tests --update-changelog` and opens a PR via `peter-evans/create-pull-request@v7`.
- Human reviews the PR (release notes for breaking changes, CI passing), merges, and decides whether to cut a `v1.x.y` project release tag. **Tagging stays manual** — that's the quality gate against shipping an upstream regression to users.

## PAT note (operational)

PRs created with the default `GITHUB_TOKEN` do not trigger other workflows — this is a GitHub security restriction, not something the action controls. Two options:

- **Without a PAT**: the refresh PR lands but CI checks don't run. Close and immediately reopen the PR to force CI (or push an empty commit).
- **With a PAT**: create a fine-grained PAT scoped to this repo with `contents: write` and `pull-requests: write`, store it as repository secret `REFRESH_BOT_TOKEN`. The workflow uses it automatically (`token: ${{ secrets.REFRESH_BOT_TOKEN || secrets.GITHUB_TOKEN }}`).

Documented inline in the workflow file as well.

## Manual setup you must do

1. **Merge this PR.** Dependabot needs the config committed on `main` before it starts opening PRs.
2. **Optionally create `REFRESH_BOT_TOKEN`** (fine-grained PAT, scoped to this repo, `contents: write` + `pull-requests: write`). Skip if you don't mind the close+reopen workaround.
3. First Dependabot runs on the next weekly Monday window; first pgagroal watcher run on the next Monday at 07:00 UTC. To test immediately after merge: `gh workflow run refresh-pgagroal-upstream.yml` (no-op today since you're on pgagroal 2.0.2, the current upstream latest).

## Test plan

- [x] `actionlint` on the new workflow — clean
- [x] dependabot.yml schema: standard v2 config, matches GitHub docs
- [x] refresh script `--skip-tests --update-changelog` path exercised by existing `make test-refresh` against the script itself