### PR TITLE
specs: add project-release flow + backfill Status headers

### DIFF
--- a/specifications/java-hibernate-transaction-pooling/spec.md
+++ b/specifications/java-hibernate-transaction-pooling/spec.md
@@ -1,5 +1,7 @@
 # Specification: Java/Hibernate Transaction Pooling Compatibility Validation
 
+Status: ACTIVE
+
 ## Objective
 
 Determine, with evidence, whether each of three Java/Hibernate applications

--- a/specifications/project-release/acceptance-cases.md
+++ b/specifications/project-release/acceptance-cases.md
@@ -1,0 +1,335 @@
+# Acceptance Cases: Project Release
+
+Derived from `spec.md`. Each case maps to an invariant, gate, postcondition,
+or failure condition in the specification. Cases are language-neutral; the
+implementation may realize them as shell tests, Go tests, GitHub Actions
+job assertions, or a mix.
+
+Tags: `[invariant]` `[gate-X]` `[postcondition]` `[failure]`.
+
+## AC-01: Version triple consistency — happy path  `[invariant]`
+
+**Given**: `VERSION` contains `1.1.0`, `Chart.yaml` `version: 1.1.0`,
+proposed tag `v1.1.0`
+**When**: `make prepare-release` runs
+**Then**:
+- Exit code 0
+- Output reports "VERSION matches Chart.yaml version"
+- Output reports "tag v1.1.0 does not exist yet"
+
+## AC-02: Version triple inconsistency — VERSION vs Chart.yaml  `[invariant] [gate-F]`
+
+**Given**: `VERSION` contains `1.1.0`, `Chart.yaml` `version: 1.0.1`
+**When**: `make prepare-release` runs
+**Then**:
+- Exit code non-zero (or warning count > 0 in current implementation)
+- Output identifies the mismatch with both values
+
+## AC-03: pgagroal version consistency  `[invariant] [gate-F]`
+
+**Given**: Dockerfile, Makefile, Chart.yaml `appVersion`, values.yaml
+`image.tag` all show `2.1.0`
+**When**: `make prepare-release` runs
+**Then**:
+- Exit code 0
+- Output reports "pgagroal version consistent across all files (2.1.0)"
+
+## AC-04: pgagroal version drift  `[invariant] [gate-F]`
+
+**Given**: Dockerfile shows `2.1.0` but `values.yaml` `image.tag: "2.0.2"`
+**When**: `make prepare-release` runs
+**Then**:
+- Exit code non-zero
+- Output enumerates each file and its detected value
+
+## AC-05: Tag format — stable  `[invariant]`
+
+**Given**: `VERSION` contains `1.1.0`
+**When**: the publish workflow runs on tag push `v1.1.0`
+**Then**:
+- The Docker metadata step produces image tags `1.1.0`, `1.1`, `latest`
+
+## AC-06: Tag format — RC  `[invariant]`
+
+**Given**: `VERSION` contains `1.1.0-rc1`
+**When**: the publish workflow runs on tag push `v1.1.0-rc1`
+**Then**:
+- The Docker metadata step produces image tag `1.1.0-rc1` only
+- `1.1` and `latest` aliases on Docker Hub are unchanged from the previous
+  stable
+
+## AC-07: Tag format — RC must not promote latest  `[invariant]`
+
+**Given**: previous stable digest D₀ at `latest` and `1.0`
+**When**: an RC release `v1.1.0-rc1` is published
+**Then**:
+- `docker buildx imagetools inspect elevarq/pgagroal:latest` returns digest D₀
+- `docker buildx imagetools inspect elevarq/pgagroal:1.0` returns digest D₀
+
+## AC-08: Changelog dated section present  `[gate-F]`
+
+**Given**: `VERSION` is `1.1.0`, today is `2026-04-29`
+**When**: a Gate F enforcement script reads `CHANGELOG.md`
+**Then**:
+- A line matching `^## \[1\.1\.0\] - \d{4}-\d{2}-\d{2}$` exists
+- The date is not in the future (UTC)
+
+## AC-09: Changelog missing dated section  `[failure] [gate-F]`
+
+**Given**: `VERSION` is `1.1.0` but `CHANGELOG.md` only contains
+`## [Unreleased]`
+**When**: Gate F enforcement runs
+**Then**:
+- Exit code non-zero
+- Error message names the missing version
+
+## AC-10: Release class — explicit field present and valid  `[gate-F]`
+
+**Given**: `CHANGELOG.md` section for `1.1.0` contains
+`Class: breaking-config` as the first non-blank line under the heading
+**When**: Gate F enforcement runs
+**Then**:
+- F4 passes (field present, value valid)
+
+## AC-10b: Release class — explicit field missing  `[gate-F] [failure]`
+
+**Given**: `CHANGELOG.md` section for `1.1.0` has no `Class:` line
+**When**: Gate F enforcement runs
+**Then**:
+- Exit code non-zero
+- Error message cites F4 and names the missing field
+
+## AC-10c: Release class — invalid value  `[gate-F] [failure]`
+
+**Given**: `CHANGELOG.md` section for `1.1.0` contains
+`Class: experimental`
+**When**: Gate F enforcement runs
+**Then**:
+- Exit code non-zero
+- Error message cites F4 and lists the four valid values
+
+## AC-11: Release class — breaking-config requires migration doc  `[gate-F]`
+
+**Given**: `CHANGELOG.md` section for `1.1.0` contains
+`Class: breaking-config`
+**When**: Gate F enforcement runs
+**Then**:
+- F5 passes only if `docs/operations/migrations/1.1.0.md` exists
+- If the migration doc is absent, exit code non-zero with a message
+  citing F5
+
+## AC-11b: Release class — non-breaking does NOT require migration doc  `[gate-F]`
+
+**Given**: `CHANGELOG.md` section for `1.0.2` contains `Class: fix`,
+no migration doc exists
+**When**: Gate F enforcement runs
+**Then**:
+- F5 passes (does not apply when class is not `breaking-config`)
+
+## AC-12: Release class — security requires Security subsection  `[gate-F]`
+
+**Given**: `CHANGELOG.md` section for `1.0.3` contains `Class: security`
+**When**: Gate F enforcement runs
+**Then**:
+- A `### Security` subsection exists under `## [1.0.3] - <date>`
+- If absent, exit code non-zero with a message citing F6
+
+## AC-12b: Release class — feature/fix has no extra requirement  `[gate-F]`
+
+**Given**: `CHANGELOG.md` section for `1.0.2` contains `Class: fix`
+and only a `### Fixed` subsection
+**When**: Gate F enforcement runs
+**Then**:
+- Exit code 0 (F5 and F6 do not apply)
+
+## AC-13: Working tree clean at tag time  `[gate-D]`
+
+**Given**: `git status` shows uncommitted changes
+**When**: an operator attempts to create the release tag
+**Then**:
+- The release flow halts before tag creation
+- (Today this is a manual step; the spec mandates that automation must not
+  proceed past this check)
+
+## AC-14: Trivy CRITICAL on built image  `[gate-C] [failure]`
+
+**Given**: `trivy image pgagroal:<pgagroal-ver>` reports a CRITICAL finding
+**When**: Gate C runs in the publish workflow
+**Then**:
+- Workflow exit code non-zero
+- Image is not pushed
+- The release tag remains but the Docker Hub image is absent
+
+## AC-15: Trivy HIGH with documented justification  `[gate-C]`
+
+**Given**: a HIGH finding exists with no upstream patch and is listed in
+`.trivyignore` with a justification comment
+**When**: Gate C runs
+**Then**:
+- Workflow exits 0
+- The justification appears in the workflow log (or release evidence)
+
+## AC-16: Gitleaks finding  `[gate-C] [failure]`
+
+**Given**: `gitleaks detect --source .` returns any finding
+**When**: Gate C runs
+**Then**:
+- Workflow exit code non-zero
+- Image is not pushed
+- The finding must be remediated and the affected secret rotated before
+  the tag is re-pushed
+
+## AC-17: Hadolint failure on Dockerfile  `[gate-B] [failure]`
+
+**Given**: `hadolint Dockerfile` returns a violation at error severity
+**When**: Gate B runs
+**Then**:
+- Workflow exit code non-zero
+- Image is not pushed
+
+## AC-18: Action pinning  `[gate-D]`
+
+**Given**: every action reference in `.github/workflows/*.yml`
+**When**: Gate D runs
+**Then**:
+- Each `uses:` line references a tag or SHA, not a branch (e.g. not
+  `@master`, not `@main`)
+
+## AC-19: Multi-arch manifest  `[postcondition]`
+
+**Given**: a stable release `v1.1.0` has been published
+**When**: `docker buildx imagetools inspect elevarq/pgagroal:1.1.0`
+**Then**:
+- The output includes both `linux/amd64` and `linux/arm64` platforms
+
+## AC-20: Cosign signature verifies  `[postcondition]`
+
+**Given**: a stable release `v1.1.0` has been published
+**When**:
+```
+cosign verify elevarq/pgagroal:1.1.0 \
+  --certificate-identity-regexp "https://github.com/Elevarq/pgAgroal/.*" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+```
+**Then**:
+- Exit code 0
+- At least one valid signature is reported
+
+## AC-21: SBOM attestation present  `[postcondition]`
+
+**Given**: a stable release `v1.1.0`
+**When**: `cosign download attestation --predicate-type https://spdx.dev/Document elevarq/pgagroal:1.1.0`
+**Then**:
+- Exit code 0
+- Output is a valid SPDX-JSON document
+
+## AC-22: SLSA provenance attestation present  `[postcondition]`
+
+**Given**: a stable release `v1.1.0`
+**When**: `cosign download attestation --predicate-type https://slsa.dev/provenance/v1 elevarq/pgagroal:1.1.0`
+**Then**:
+- Exit code 0
+- Output validates as SLSA provenance v1
+
+## AC-23: GitHub Release exists with changelog body  `[postcondition]`
+
+**Given**: a tag `v1.1.0` was pushed and the publish workflow completed
+**When**: `gh release view v1.1.0 --json body`
+**Then**:
+- Exit code 0
+- The `body` field contains the corresponding `CHANGELOG.md` section text
+
+## AC-24: stable aliases promoted  `[postcondition]`
+
+**Given**: a stable release `v1.1.0` has been published
+**When**: digests are inspected
+**Then**:
+- `elevarq/pgagroal:1.1.0`, `elevarq/pgagroal:1.1`, `elevarq/pgagroal:latest`
+  share the same multi-arch index digest
+
+## AC-25: RC aliases not promoted  `[postcondition]`
+
+**Given**: an RC release `v1.1.0-rc1` has been published while latest stable
+is `v1.0.1`
+**When**: digests are inspected
+**Then**:
+- `elevarq/pgagroal:1.1.0-rc1` exists
+- `elevarq/pgagroal:1.1` does NOT exist (or points elsewhere; it must not
+  point at the RC digest)
+- `elevarq/pgagroal:latest` still points at the `1.0.1` digest
+
+## AC-26: Idempotent tag — re-pushing the same tag does not republish  `[invariant]`
+
+**Given**: tag `v1.1.0` already exists locally and remote
+**When**: an operator runs `git push origin v1.1.0` again
+**Then**:
+- The push is a no-op (or rejected by branch protection)
+- No second publish workflow runs
+
+## AC-27: Retracted tag flow  `[failure]`
+
+**Given**: a tag `v1.1.0` was pushed but the publish workflow failed at
+Gate C
+**When**: the operator runs `git push origin :v1.1.0`, fixes the issue,
+and re-pushes `v1.1.0`
+**Then**:
+- The publish workflow runs again on the new tag commit
+- The image tag `1.1.0` on Docker Hub points at the digest produced by the
+  re-run
+
+> Note: this case is acceptable only when no consumer has pulled the
+> original failed image. If the original ran far enough to push, the
+> spec-mandated flow is a follow-up patch release, not a re-tag.
+
+## AC-28: README pinned-versions reflects current pins  `[gate-F]`
+
+**Given**: `Dockerfile` pins pgagroal `2.1.0`
+**When**: Gate F runs
+**Then**:
+- `README.md` "Pinned versions" table contains `2.1.0`
+- (Today this is a manual review item; the spec mandates that automation
+  must verify it before tag.)
+
+## AC-29: DOCKER_HUB.md references the release version  `[gate-F]`
+
+**Given**: a release `v1.1.0`
+**When**: Gate F runs
+**Then**:
+- `DOCKER_HUB.md` contains `elevarq/pgagroal:1.1.0` in the quickstart and
+  cosign-verify snippets
+- `DOCKER_HUB.md` does not contain references to the previous version
+  (`1.0.1`) in those snippets
+
+## AC-30: Docker Hub overview synchronized post-release  `[postcondition]`
+
+**Given**: a stable release `v1.1.0` has been published and merged to main
+**When**: `.github/workflows/dockerhub-description.yml` completes
+**Then**:
+- The repo overview on hub.docker.com matches the contents of
+  `DOCKER_HUB.md` at the release commit
+
+---
+
+## Coverage map
+
+Every spec rule is referenced by at least one acceptance case. Conversely,
+every acceptance case references at least one spec element.
+
+| Spec element | Cases |
+|---|---|
+| Invariant 1 (project version triple) | AC-01, AC-02 |
+| Invariant 2 (pgagroal version quad) | AC-03, AC-04 |
+| Invariant 3 (changelog dated) | AC-08, AC-09 |
+| Invariant 4 (no manual push) | enforced by repo policy, not testable in isolation |
+| Invariant 5 (reproducibility) | implicit — verified by build determinism, future work |
+| Invariant 6 (RC never promotes) | AC-06, AC-07, AC-25 |
+| Invariant 7 (X.Y / latest point at stable) | AC-24 |
+| Gate A | AC-19 (artifact built); rest covered by existing test specs |
+| Gate B | AC-17, AC-18 |
+| Gate C | AC-14, AC-15, AC-16 |
+| Gate D | AC-13, AC-18 |
+| Gate E | AC-19, AC-21, AC-22, AC-20 |
+| Gate F | AC-01..AC-04, AC-08..AC-12b, AC-28, AC-29 |
+| Postconditions Q1–Q9 | AC-19..AC-25, AC-30 |
+| Failure: retraction | AC-27 |
+| Failure: idempotent push | AC-26 |

--- a/specifications/project-release/spec.md
+++ b/specifications/project-release/spec.md
@@ -1,0 +1,272 @@
+# Specification: Project Release
+
+Status: ACTIVE
+
+## Purpose
+
+Define the end-to-end workflow for cutting a release of the **container project
+itself** — the artifact tracked by `VERSION`, published as
+`elevarq/pgagroal:<X.Y.Z>` to Docker Hub, and tagged as `v<X.Y.Z>` on
+`Elevarq/pgAgroal`.
+
+This specification governs the *packaging* release. It does **not** govern the
+upstream pgagroal version bump (that is `specifications/release-refresh/`),
+nor the downstream fan-out to the website and blog (those are separate
+concerns).
+
+The two specs compose:
+
+```
+release-refresh  →  project-release  →  (downstream surfaces)
+upstream bump       packaging tag        website / blog / Docker Hub overview
+```
+
+## Inputs
+
+| Input | Source | Required | Default |
+|---|---|---|---|
+| Target project version | `VERSION` file content | Yes | none |
+| Release channel | `stable` (e.g. `1.1.0`) or `rc` (e.g. `1.1.0-rc1`) | Yes | `stable` |
+| Pinned pgagroal version | `Dockerfile` `ARG PGAGROAL_VERSION` | Yes | inherited from `release-refresh` |
+
+### Version format
+
+- Stable: `^[0-9]+\.[0-9]+\.[0-9]+$` (e.g. `1.1.0`)
+- RC: `^[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$` (e.g. `1.1.0-rc1`)
+
+The git tag is always the version with a `v` prefix: `v1.1.0`, `v1.1.0-rc1`.
+
+### Release class
+
+A release belongs to exactly one class, declared **explicitly** as the first
+non-blank line under the version heading in `CHANGELOG.md`:
+
+```
+## [1.1.0] - 2026-04-29
+
+Class: breaking-config
+
+### Migration
+...
+```
+
+The `Class:` field is required for every dated changelog section. Valid
+values and their extra requirements:
+
+| Class | Trigger | Extra requirement |
+|---|---|---|
+| `feature` | New functionality, no breaking change | none |
+| `fix` | Bug fix only | none |
+| `security` | Security fix or hardening | `### Security` subsection in changelog |
+| `breaking-config` | Operator-visible config or data migration required | `docs/operations/migrations/<version>.md` exists |
+
+The class is read from the explicit field — never inferred from
+subsection structure. This makes the release intent unambiguous at a
+glance and gives Gate F a single deterministic field to validate.
+
+## Outputs
+
+On success a project release produces:
+
+1. A signed git tag `v<X.Y.Z>` on `main` of `Elevarq/pgAgroal`.
+2. A multi-arch container image at `elevarq/pgagroal:<X.Y.Z>` covering
+   `linux/amd64` and `linux/arm64`.
+3. Image tags on Docker Hub (per `docs/release/release-checklist.md`):
+   - Stable: `<X.Y.Z>`, `<X.Y>`, `latest`
+   - RC: `<X.Y.Z>-rc<N>` only — must not update `<X.Y>` or `latest`
+4. A cosign keyless signature on the published image (GitHub OIDC issuer).
+5. An SBOM attestation (SPDX-JSON) attached to the image.
+6. A SLSA provenance attestation (`mode=max`) attached to the image.
+7. A GitHub Release object for the tag, with body sourced from the
+   corresponding `CHANGELOG.md` section.
+8. An updated Docker Hub repository overview rendered from `DOCKER_HUB.md`
+   (via `.github/workflows/dockerhub-description.yml`).
+
+## Invariants
+
+1. The project version appears identically in three locations:
+   - `VERSION` (entire file content)
+   - `helm/pgagroal/Chart.yaml` `version:`
+   - The git tag, with a `v` prefix
+2. The pinned pgagroal version appears identically in four locations
+   (already enforced by `release-refresh`):
+   - `Dockerfile` `ARG PGAGROAL_VERSION`
+   - `Makefile` `IMAGE_TAG`
+   - `helm/pgagroal/Chart.yaml` `appVersion`
+   - `helm/pgagroal/values.yaml` `image.tag`
+3. The `CHANGELOG.md` contains a section `## [<X.Y.Z>] - <YYYY-MM-DD>` that
+   matches the release version and is dated to the release day (UTC).
+4. No image is published to Docker Hub outside of `.github/workflows/publish.yml`.
+5. A given git tag always produces the same image content modulo base image
+   layer updates (reproducibility per parent CLAUDE.md).
+6. RC tags never alias to `<X.Y>` or `latest`.
+7. The `<X.Y>` and `latest` aliases on Docker Hub always point to a `stable`
+   tag of the corresponding line.
+
+## Preconditions (release gates)
+
+The six gates from the parent CLAUDE.md `Release Protocol`, applied to a
+project release. All gates are mandatory; failure of any gate halts the
+release.
+
+### Gate A — Correctness
+
+| # | Check | Tool / target |
+|---|---|---|
+| A1 | Unit + integration tests pass against the **built artifact** | `make test-all` |
+| A2 | Docker-restart resilience test passes | `make test-docker-restart` |
+| A3 | Backend-restart resilience test passes | `make test-backend-restart` |
+| A4 | Startup-failure test passes | `make test-startup-failure` |
+| A5 | Helm chart renders | `make helm-template` |
+
+### Gate B — Lint / Quality
+
+| # | Check | Tool |
+|---|---|---|
+| B1 | Dockerfile lint | `hadolint Dockerfile` |
+| B2 | GitHub Actions lint | `actionlint` |
+| B3 | Helm chart lint | `make helm-lint` (i.e. `helm lint`) |
+| B4 | Shell script lint (entrypoint, scripts/) | `shellcheck` (where present) |
+| B5 | YAML lint on configs and chart values | `yamllint` |
+
+### Gate C — Security
+
+| # | Check | Tool | Severity rule |
+|---|---|---|---|
+| C1 | Filesystem vuln + secret scan | `trivy fs --scanners vuln,secret .` | CRITICAL → STOP; HIGH → fix or document |
+| C2 | Config / IaC scan | `trivy config .` | same |
+| C3 | Image scan against the built artifact | `trivy image pgagroal:<pgagroal-ver>` | same |
+| C4 | Full-history secret scan | `gitleaks detect --source .` | any finding → STOP |
+
+### Gate D — Supply Chain
+
+| # | Check |
+|---|---|
+| D1 | `Dockerfile` base images pinned to a specific tag (no `:latest`) |
+| D2 | All GitHub Actions in `.github/workflows/` pinned to a major version tag (`@vN`) at minimum |
+| D3 | Working tree is clean — no uncommitted changes when the tag is created |
+| D4 | `go.sum` / lock files (where applicable) committed and matching |
+| D5 | No vendored secrets or credentials in the repository |
+
+### Gate E — Artifact
+
+| # | Check |
+|---|---|
+| E1 | Multi-arch image builds (`linux/amd64`, `linux/arm64`) |
+| E2 | SBOM generated (`syft` or build-attestation) |
+| E3 | SLSA provenance generated (`mode=max`) |
+| E4 | Cosign signature applied (keyless, GitHub OIDC) |
+
+### Gate F — Release Hygiene
+
+| # | Check |
+|---|---|
+| F1 | `VERSION` matches `Chart.yaml` `version` matches the proposed tag |
+| F2 | pgagroal version consistency holds (Invariant #2) |
+| F3 | `CHANGELOG.md` has a dated section for the release version (Invariant #3) |
+| F4 | The dated section contains a `Class:` field with a valid value (`feature`, `fix`, `security`, `breaking-config`) |
+| F5 | If `Class: breaking-config`: `docs/operations/migrations/<version>.md` exists |
+| F6 | If `Class: security`: `### Security` subsection present in changelog |
+| F7 | `README.md` "Pinned versions" table reflects current pinned versions |
+| F8 | `DOCKER_HUB.md` quick-start and verification snippets reference the release version |
+
+`make prepare-release` runs F1–F2 today. F3–F8 are added by this spec.
+
+## Postconditions
+
+After the publish workflow completes for a `v<X.Y.Z>` push:
+
+| # | Postcondition | How to verify |
+|---|---|---|
+| Q1 | Publish workflow run for the tag exists and exited 0 | `gh run list --workflow publish.yml` |
+| Q2 | Image `elevarq/pgagroal:<X.Y.Z>` exists on Docker Hub with a multi-arch index | `docker buildx imagetools inspect elevarq/pgagroal:<X.Y.Z>` |
+| Q3 | For stable releases: `<X.Y>` and `latest` aliases point to the same digest as `<X.Y.Z>` | `docker buildx imagetools inspect` of each |
+| Q4 | For RC releases: `<X.Y>` and `latest` are unchanged from the previous stable | digest comparison |
+| Q5 | Cosign signature verifies | `cosign verify elevarq/pgagroal:<X.Y.Z> --certificate-identity-regexp "https://github.com/Elevarq/pgAgroal/.*" --certificate-oidc-issuer "https://token.actions.githubusercontent.com"` |
+| Q6 | SBOM attestation present | `cosign download attestation --predicate-type https://spdx.dev/Document elevarq/pgagroal:<X.Y.Z>` |
+| Q7 | SLSA provenance attestation present | `cosign download attestation --predicate-type https://slsa.dev/provenance/v1 elevarq/pgagroal:<X.Y.Z>` |
+| Q8 | GitHub Release object exists with the changelog body | `gh release view v<X.Y.Z>` |
+| Q9 | Docker Hub overview matches `DOCKER_HUB.md` of the tagged commit | manual check on hub.docker.com |
+
+## Processing steps (deterministic order)
+
+A project release executes as a sequence of three phases. Each phase has a
+clear human / automation handoff.
+
+### Phase 1 — Preparation (human-driven, on a feature branch)
+
+1. Confirm the upstream refresh has landed (per `release-refresh` spec).
+2. Edit `VERSION` to the new project version.
+3. Edit `helm/pgagroal/Chart.yaml` `version:` to match.
+4. Edit `CHANGELOG.md`: convert `## [Unreleased]` to `## [<X.Y.Z>] - <date>`,
+   add a `Class: <feature|fix|security|breaking-config>` line as the first
+   non-blank line under the heading, and add the appropriate subsections.
+5. Edit `README.md` "Pinned versions" table.
+6. Edit `DOCKER_HUB.md` quick-start and verification snippets.
+7. If `Class: breaking-config`: author `docs/operations/migrations/<version>.md`.
+8. Run `make prepare-release` and resolve any reported issue.
+9. Open a PR, get it merged to `main` through normal review.
+
+### Phase 2 — Tag and publish (automation-driven)
+
+10. From `main` at the merge commit, create and push the annotated tag:
+    ```
+    git tag -a v<X.Y.Z> -m "Release v<X.Y.Z> (pgagroal <pgagroal-ver>)"
+    git push origin v<X.Y.Z>
+    ```
+11. `.github/workflows/publish.yml` runs all six release gates, builds
+    multi-arch, generates SBOM + provenance, signs with cosign, pushes to
+    Docker Hub, and creates the GitHub Release. (Today the workflow runs
+    Gates A, C, E. Gates B, D, F are extended by this spec.)
+12. `.github/workflows/dockerhub-description.yml` updates the Docker Hub
+    overview from `DOCKER_HUB.md`.
+
+### Phase 3 — Post-release verification (human-driven)
+
+13. Verify all postconditions Q1–Q9.
+14. Roll out to a non-production environment first; for `breaking-config`
+    releases, exercise the migration path before any production use.
+15. Announce per `docs/release/release-evidence-checklist.md`.
+
+## Failure conditions
+
+| Phase | Failure | Effect |
+|---|---|---|
+| Phase 1 | Any Gate F check fails locally | PR cannot merge; fix on the feature branch |
+| Phase 1 | `Class:` field missing or invalid in the dated changelog section | F4 fails |
+| Phase 1 | `Class: breaking-config` declared but migration doc missing | F5 fails |
+| Phase 1 | `Class: security` declared but `### Security` subsection missing | F6 fails |
+| Phase 2 | Any of Gates A–F fail in CI | publish workflow exits non-zero; tag remains but no image is published; remediate by deleting the tag (`git push origin :v<X.Y.Z>`), fixing on a new branch, and re-tagging |
+| Phase 2 | CRITICAL CVE found by Trivy | STOP per parent CLAUDE.md severity rule |
+| Phase 2 | Any gitleaks finding | STOP — secret rotation required before retag |
+| Phase 2 | Cosign signing fails (OIDC error) | STOP — image must not be published unsigned; rerun workflow after diagnosing |
+| Phase 3 | Cosign verify or attestation download fails for the published image | STOP and investigate before any consumer announcement; treat the image as untrusted until resolved |
+
+## Rollback / cleanup expectations
+
+This spec does NOT define automated rollback of a published image. A
+published image is immutable; "rollback" means publishing a follow-up
+release that supersedes it.
+
+If a release must be retracted before any consumer adoption:
+
+1. Delete the git tag: `git push origin :v<X.Y.Z>`
+2. Delete the Docker Hub tag manually (only if the team consensus is that
+   the broken release should not remain accessible; otherwise leave it for
+   audit trail).
+3. Cut a new release at the next patch level with a `## [<X.Y.Z+1>]`
+   changelog entry that explains the retraction.
+
+This is intentionally not automated — retracting a published artifact is a
+high-blast-radius decision that requires human judgement.
+
+## Non-goals
+
+- Bumping the upstream pgagroal version (covered by `release-refresh`).
+- Updating the marketing website or blog (separate concern, separate
+  surface, separate change cadence).
+- Mirroring the image to ECR or other private registries (covered by
+  `docs/release/release-checklist.md` operational steps, not by this
+  spec).
+- Authoring release announcements or social posts.
+- Dependency bumping (Dependabot / renovate own that).

--- a/specifications/release-refresh/spec.md
+++ b/specifications/release-refresh/spec.md
@@ -1,5 +1,7 @@
 # Specification: pgagroal Upstream Version Refresh
 
+Status: ACTIVE
+
 ## Purpose
 
 Provide a repeatable, scriptable workflow for updating the bundled pgagroal


### PR DESCRIPTION
## Summary

- Adds STDD specification `specifications/project-release/` (spec + 30 acceptance cases) governing the end-to-end project release flow — composes with the existing `release-refresh` spec which handles only the upstream pgagroal bump.
- Codifies the version-triple invariant (`VERSION` ↔ `Chart.yaml` `version` ↔ git tag), the six release-protocol gates from the parent CLAUDE.md, RC-vs-stable tag aliasing rules, and post-publish verification (cosign, SBOM, SLSA provenance, Docker Hub overview).
- Introduces an explicit `Class:` field in each dated `CHANGELOG.md` section with four valid values: `feature`, `fix`, `security`, `breaking-config`. `breaking-config` releases require a `docs/operations/migrations/<version>.md`; `security` releases require a `### Security` subsection. The class is declared, never inferred from subsection structure.
- Backfills `Status: ACTIVE` headers on the existing `release-refresh` and `java-hibernate-transaction-pooling` specs to match the `docker-restart-resilience` convention.

## Scope (intentionally narrow)

This PR lands the spec only. The new Gate F enforcement (F3–F8) is **not yet wired into `make prepare-release` or `.github/workflows/publish.yml`** — that follows in a separate PR with its own acceptance cases, per STDD's spec-before-code rule.

## Composition with existing specs

```
release-refresh   →   project-release   →   (downstream surfaces)
upstream bump         packaging tag         website / blog / Docker Hub overview
```

## Test plan

- [ ] Review spec for coverage of all six release gates (A–F)
- [ ] Confirm the `Class:` field convention works for the upcoming `v1.1.0` (pgagroal 2.1.0) release — that release is `breaking-config` due to the upstream vault migration, so it will be the first real exercise of F5
- [ ] Confirm acceptance-cases coverage map maps every spec rule to ≥1 case
- [ ] Sanity-check that the spec does not unintentionally constrain the existing `make prepare-release` (which still passes today on `1.0.1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)