### PR TITLE
release: enforce Gate F release-hygiene checks (F3-F8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.1] - 2026-04-14
 
+Class: fix
+
 ### Fixed
 
 - Container now survives `docker restart` (or any stop/start cycle) after

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ HELM_RELEASE := pgagroal
 HELM_CHART   := helm/pgagroal
 NAMESPACE    := pgagroal
 
-.PHONY: build run test test-backend-restart test-docker-restart test-concurrent test-pooling test-startup-failure test-invalid-creds test-all test-validation test-refresh clean stop logs helm-lint helm-template helm-install helm-upgrade helm-uninstall refresh refresh-dry-run prepare-release release-check
+.PHONY: build run test test-backend-restart test-docker-restart test-concurrent test-pooling test-startup-failure test-invalid-creds test-all test-validation test-refresh test-release-checks clean stop logs helm-lint helm-template helm-install helm-upgrade helm-uninstall refresh refresh-dry-run prepare-release release-check
 
 # ---------------------------------------------------------------------------
 # Docker
@@ -120,3 +120,7 @@ release-check:
 ## test-refresh    : Run refresh script automated tests
 test-refresh:
 	bash test/refresh/test-refresh.sh
+
+## test-release-checks : Run prepare-release.sh Gate F automated tests
+test-release-checks:
+	bash test/release-checks/test-prepare-release.sh

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -95,6 +95,77 @@ else
     ok "tag ${TAG} does not exist yet"
 fi
 
+# ── Gate F: release hygiene checks (F3–F8) ────────────────────────────────────
+# Spec: specifications/project-release/spec.md (ACTIVE)
+
+# F3: CHANGELOG.md has a dated section for the release version
+SECTION_START=""
+if [[ -f CHANGELOG.md ]]; then
+    SECTION_START=$(grep -nE "^## \[${PROJECT_VERSION//./\\.}\] - [0-9]{4}-[0-9]{2}-[0-9]{2}" CHANGELOG.md 2>/dev/null | head -1 | cut -d: -f1 || true)
+fi
+if [[ -n "${SECTION_START}" ]]; then
+    ok "F3: CHANGELOG.md has dated section for ${PROJECT_VERSION}"
+else
+    warn "F3: CHANGELOG.md has no '## [${PROJECT_VERSION}] - YYYY-MM-DD' section"
+    ERRORS=$((ERRORS + 1))
+fi
+
+# F4-F6: release class field + class-specific extra requirements
+# Only evaluated if F3 found a section to inspect.
+CLASS_VALUE=""
+if [[ -n "${SECTION_START}" ]]; then
+    SECTION_BODY=$(awk -v start="${SECTION_START}" 'NR>start { if (/^## /) exit; print }' CHANGELOG.md)
+    CLASS_LINE=$(echo "${SECTION_BODY}" | grep -m1 -vE '^[[:space:]]*$' || true)
+    if [[ "${CLASS_LINE}" =~ ^Class:[[:space:]]+(feature|fix|security|breaking-config)[[:space:]]*$ ]]; then
+        CLASS_VALUE="${BASH_REMATCH[1]}"
+        ok "F4: Class is '${CLASS_VALUE}'"
+    else
+        warn "F4: ${PROJECT_VERSION} section needs 'Class: <value>' as the first non-blank line, where <value> is one of: feature, fix, security, breaking-config"
+        ERRORS=$((ERRORS + 1))
+    fi
+fi
+
+# F5: breaking-config requires migration doc
+if [[ "${CLASS_VALUE}" = "breaking-config" ]]; then
+    if [[ -f "docs/operations/migrations/${PROJECT_VERSION}.md" ]]; then
+        ok "F5: migration doc docs/operations/migrations/${PROJECT_VERSION}.md exists"
+    else
+        warn "F5: Class is breaking-config but docs/operations/migrations/${PROJECT_VERSION}.md is missing"
+        ERRORS=$((ERRORS + 1))
+    fi
+fi
+
+# F6: security requires a ### Security subsection
+if [[ "${CLASS_VALUE}" = "security" ]]; then
+    if echo "${SECTION_BODY}" | grep -qE '^### Security[[:space:]]*$'; then
+        ok "F6: ### Security subsection present"
+    else
+        warn "F6: Class is security but ### Security subsection is missing in the ${PROJECT_VERSION} changelog section"
+        ERRORS=$((ERRORS + 1))
+    fi
+fi
+
+# F7: README.md "Pinned versions" pgagroal row matches Dockerfile pin
+if [[ -f README.md ]]; then
+    README_PG_PIN=$(sed -n 's/^| pgagroal | \([^ |]*\) |.*/\1/p' README.md | head -1)
+    if [[ "${README_PG_PIN}" = "${PGAGROAL_DOCKERFILE}" ]]; then
+        ok "F7: README.md Pinned Versions has pgagroal ${PGAGROAL_DOCKERFILE}"
+    else
+        warn "F7: README.md Pinned Versions pgagroal=${README_PG_PIN:-<missing>}, expected ${PGAGROAL_DOCKERFILE}"
+        ERRORS=$((ERRORS + 1))
+    fi
+fi
+
+# F8: DOCKER_HUB.md quickstart and verify snippets reference the project version
+if [[ -f DOCKER_HUB.md ]]; then
+    if grep -qF "elevarq/pgagroal:${PROJECT_VERSION}" DOCKER_HUB.md; then
+        ok "F8: DOCKER_HUB.md references elevarq/pgagroal:${PROJECT_VERSION}"
+    else
+        warn "F8: DOCKER_HUB.md does not reference elevarq/pgagroal:${PROJECT_VERSION}"
+        ERRORS=$((ERRORS + 1))
+    fi
+fi
+
 echo ""
 
 if [[ "${ERRORS}" -gt 0 ]]; then

--- a/test/release-checks/test-prepare-release.sh
+++ b/test/release-checks/test-prepare-release.sh
@@ -1,0 +1,396 @@
+#!/usr/bin/env bash
+#
+# Tests for scripts/prepare-release.sh — Gate F enforcement (F3–F8).
+#
+# Spec:              specifications/project-release/spec.md
+# Acceptance cases:  specifications/project-release/acceptance-cases.md
+#
+# Each test sets up a temporary worktree, mutates the fixture to a known
+# state, runs `prepare-release.sh --check-only`, and asserts the exit code
+# and output. The real repo is never modified.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PASS=0
+FAIL=0
+
+# ── test harness ──────────────────────────────────────────────────────────────
+
+WORKDIR=""
+
+setup_worktree() {
+    WORKDIR=$(mktemp -d)
+    cp -a "${SCRIPT_DIR}/." "${WORKDIR}/"
+    rm -rf "${WORKDIR}/.git"
+    git -C "${WORKDIR}" init -q -b main
+    git -C "${WORKDIR}" -c user.email=t@t -c user.name=t add -A
+    git -C "${WORKDIR}" -c user.email=t@t -c user.name=t commit -q -m baseline
+}
+
+cleanup_worktree() {
+    [[ -n "${WORKDIR}" ]] && rm -rf "${WORKDIR}"
+    WORKDIR=""
+}
+
+# Set the project version in both VERSION and Chart.yaml so F1 passes.
+set_project_version() {
+    local v="$1"
+    echo "${v}" > "${WORKDIR}/VERSION"
+    sed -i'' -e "s/^version: .*/version: ${v}/" "${WORKDIR}/helm/pgagroal/Chart.yaml"
+}
+
+# Replace the entire CHANGELOG.md with a deterministic fixture.
+write_changelog() {
+    cat > "${WORKDIR}/CHANGELOG.md"
+}
+
+# Set the README pinned-versions row for pgagroal.
+set_readme_pgagroal_pin() {
+    local v="$1"
+    sed -i'' -e "s/^| pgagroal | .* |\$/| pgagroal | ${v} |/" "${WORKDIR}/README.md"
+}
+
+# Set the DOCKER_HUB.md project version references.
+set_dockerhub_project_pin() {
+    local v="$1"
+    sed -i'' -e "s|elevarq/pgagroal:[0-9][0-9.]*|elevarq/pgagroal:${v}|g" "${WORKDIR}/DOCKER_HUB.md"
+}
+
+run_check() {
+    set +e
+    OUT=$(cd "${WORKDIR}" && bash scripts/prepare-release.sh --check-only 2>&1)
+    RC=$?
+    set -e
+}
+
+assert_exit() {
+    local name="$1" expected="$2" actual="$3"
+    if [[ "${actual}" -eq "${expected}" ]]; then
+        echo "  PASS: ${name}"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: ${name} (expected exit ${expected}, got ${actual})"
+        echo "  ----- output -----"
+        echo "${OUT}" | sed 's/^/    /'
+        echo "  ------------------"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    local name="$1" haystack="$2" needle="$3"
+    if echo "${haystack}" | grep -qE "${needle}"; then
+        echo "  PASS: ${name}"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: ${name} (output does not match /${needle}/)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_not_contains() {
+    local name="$1" haystack="$2" needle="$3"
+    if ! echo "${haystack}" | grep -qE "${needle}"; then
+        echo "  PASS: ${name}"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: ${name} (output unexpectedly matches /${needle}/)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ── tests ─────────────────────────────────────────────────────────────────────
+
+echo "=== prepare-release.sh Gate F test suite ==="
+echo ""
+
+# --------------------------------------------------------------------------
+# AC-08: Changelog dated section present  [gate-F]  (F3 happy)
+# --------------------------------------------------------------------------
+echo "--- AC-08: dated section present ---"
+setup_worktree
+set_project_version "1.1.0"
+set_readme_pgagroal_pin "2.0.2"
+set_dockerhub_project_pin "1.1.0"
+write_changelog <<'EOF'
+# Changelog
+
+## [1.1.0] - 2026-04-29
+
+Class: feature
+
+### Added
+
+- New thing.
+EOF
+git -C "${WORKDIR}" -c user.email=t@t -c user.name=t commit -q -am fixture
+run_check
+assert_exit "exit 0" 0 "${RC}"
+assert_contains "F3 ok" "${OUT}" "F3.*1\\.1\\.0"
+cleanup_worktree
+
+# --------------------------------------------------------------------------
+# AC-09: Changelog missing dated section  [gate-F] [failure]  (F3 fail)
+# --------------------------------------------------------------------------
+echo "--- AC-09: dated section missing ---"
+setup_worktree
+set_project_version "1.1.0"
+set_readme_pgagroal_pin "2.0.2"
+set_dockerhub_project_pin "1.1.0"
+write_changelog <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+- WIP.
+EOF
+git -C "${WORKDIR}" -c user.email=t@t -c user.name=t commit -q -am fixture
+run_check
+assert_exit "exit 1" 1 "${RC}"
+assert_contains "F3 cited" "${OUT}" "F3"
+assert_contains "names version" "${OUT}" "1\\.1\\.0"
+cleanup_worktree
+
+# --------------------------------------------------------------------------
+# AC-10: Class field present and valid  [gate-F]  (F4 happy)
+# --------------------------------------------------------------------------
+echo "--- AC-10: Class field present and valid ---"
+setup_worktree
+set_project_version "1.1.0"
+set_readme_pgagroal_pin "2.0.2"
+set_dockerhub_project_pin "1.1.0"
+write_changelog <<'EOF'
+# Changelog
+
+## [1.1.0] - 2026-04-29
+
+Class: breaking-config
+
+### Migration
+
+- Vault rotation required.
+EOF
+mkdir -p "${WORKDIR}/docs/operations/migrations"
+echo "# Migration to 1.1.0" > "${WORKDIR}/docs/operations/migrations/1.1.0.md"
+git -C "${WORKDIR}" -c user.email=t@t -c user.name=t add -A
+git -C "${WORKDIR}" -c user.email=t@t -c user.name=t commit -q -m fixture
+run_check
+assert_exit "exit 0" 0 "${RC}"
+assert_contains "F4 ok with breaking-config" "${OUT}" "F4.*breaking-config"
+cleanup_worktree
+
+# --------------------------------------------------------------------------
+# AC-10b: Class field missing  [gate-F] [failure]  (F4 fail)
+# --------------------------------------------------------------------------
+echo "--- AC-10b: Class field missing ---"
+setup_worktree
+set_project_version "1.1.0"
+set_readme_pgagroal_pin "2.0.2"
+set_dockerhub_project_pin "1.1.0"
+write_changelog <<'EOF'
+# Changelog
+
+## [1.1.0] - 2026-04-29
+
+### Added
+
+- New thing.
+EOF
+git -C "${WORKDIR}" -c user.email=t@t -c user.name=t commit -q -am fixture
+run_check
+assert_exit "exit 1" 1 "${RC}"
+assert_contains "F4 cited" "${OUT}" "F4"
+cleanup_worktree
+
+# --------------------------------------------------------------------------
+# AC-10c: Class field invalid value  [gate-F] [failure]  (F4 fail)
+# --------------------------------------------------------------------------
+echo "--- AC-10c: Class field invalid value ---"
+setup_worktree
+set_project_version "1.1.0"
+set_readme_pgagroal_pin "2.0.2"
+set_dockerhub_project_pin "1.1.0"
+write_changelog <<'EOF'
+# Changelog
+
+## [1.1.0] - 2026-04-29
+
+Class: experimental
+
+### Added
+
+- New thing.
+EOF
+git -C "${WORKDIR}" -c user.email=t@t -c user.name=t commit -q -am fixture
+run_check
+assert_exit "exit 1" 1 "${RC}"
+assert_contains "F4 cited" "${OUT}" "F4"
+assert_contains "lists valid values" "${OUT}" "feature.*fix.*security.*breaking-config"
+cleanup_worktree
+
+# --------------------------------------------------------------------------
+# AC-11: breaking-config requires migration doc  [gate-F]  (F5 fail)
+# --------------------------------------------------------------------------
+echo "--- AC-11: breaking-config without migration doc ---"
+setup_worktree
+set_project_version "1.1.0"
+set_readme_pgagroal_pin "2.0.2"
+set_dockerhub_project_pin "1.1.0"
+write_changelog <<'EOF'
+# Changelog
+
+## [1.1.0] - 2026-04-29
+
+Class: breaking-config
+
+### Migration
+
+- Vault rotation required.
+EOF
+# NB: migration doc deliberately not created
+git -C "${WORKDIR}" -c user.email=t@t -c user.name=t commit -q -am fixture
+run_check
+assert_exit "exit 1" 1 "${RC}"
+assert_contains "F5 cited" "${OUT}" "F5"
+assert_contains "names migration path" "${OUT}" "migrations/1\\.1\\.0\\.md"
+cleanup_worktree
+
+# --------------------------------------------------------------------------
+# AC-11b: non-breaking does NOT require migration doc  [gate-F]  (F5 n/a)
+# --------------------------------------------------------------------------
+echo "--- AC-11b: non-breaking does not require migration doc ---"
+setup_worktree
+set_project_version "1.0.2"
+set_readme_pgagroal_pin "2.0.2"
+set_dockerhub_project_pin "1.0.2"
+write_changelog <<'EOF'
+# Changelog
+
+## [1.0.2] - 2026-04-29
+
+Class: fix
+
+### Fixed
+
+- Small bug.
+EOF
+git -C "${WORKDIR}" -c user.email=t@t -c user.name=t commit -q -am fixture
+run_check
+assert_exit "exit 0" 0 "${RC}"
+assert_not_contains "F5 not raised" "${OUT}" "F5"
+cleanup_worktree
+
+# --------------------------------------------------------------------------
+# AC-12: security requires Security subsection  [gate-F]  (F6 fail)
+# --------------------------------------------------------------------------
+echo "--- AC-12: security without Security subsection ---"
+setup_worktree
+set_project_version "1.0.3"
+set_readme_pgagroal_pin "2.0.2"
+set_dockerhub_project_pin "1.0.3"
+write_changelog <<'EOF'
+# Changelog
+
+## [1.0.3] - 2026-04-29
+
+Class: security
+
+### Fixed
+
+- Some fix without naming the CVE.
+EOF
+git -C "${WORKDIR}" -c user.email=t@t -c user.name=t commit -q -am fixture
+run_check
+assert_exit "exit 1" 1 "${RC}"
+assert_contains "F6 cited" "${OUT}" "F6"
+cleanup_worktree
+
+# --------------------------------------------------------------------------
+# AC-12b: feature/fix has no extra requirement  [gate-F]
+# --------------------------------------------------------------------------
+echo "--- AC-12b: fix class has no extra requirement ---"
+setup_worktree
+set_project_version "1.0.2"
+set_readme_pgagroal_pin "2.0.2"
+set_dockerhub_project_pin "1.0.2"
+write_changelog <<'EOF'
+# Changelog
+
+## [1.0.2] - 2026-04-29
+
+Class: fix
+
+### Fixed
+
+- Small bug.
+EOF
+git -C "${WORKDIR}" -c user.email=t@t -c user.name=t commit -q -am fixture
+run_check
+assert_exit "exit 0" 0 "${RC}"
+assert_not_contains "F5 not raised" "${OUT}" "F5"
+assert_not_contains "F6 not raised" "${OUT}" "F6"
+cleanup_worktree
+
+# --------------------------------------------------------------------------
+# AC-28: README pinned-versions reflects current pin  [gate-F]  (F7 fail)
+# --------------------------------------------------------------------------
+echo "--- AC-28: README pinned versions stale ---"
+setup_worktree
+set_project_version "1.1.0"
+# Dockerfile pins 2.0.2, but README claims pgagroal 1.0.0 — mismatch
+set_readme_pgagroal_pin "1.0.0"
+set_dockerhub_project_pin "1.1.0"
+write_changelog <<'EOF'
+# Changelog
+
+## [1.1.0] - 2026-04-29
+
+Class: feature
+
+### Added
+
+- thing.
+EOF
+git -C "${WORKDIR}" -c user.email=t@t -c user.name=t commit -q -am fixture
+run_check
+assert_exit "exit 1" 1 "${RC}"
+assert_contains "F7 cited" "${OUT}" "F7"
+cleanup_worktree
+
+# --------------------------------------------------------------------------
+# AC-29: DOCKER_HUB.md references the release version  [gate-F]  (F8 fail)
+# --------------------------------------------------------------------------
+echo "--- AC-29: DOCKER_HUB.md references stale version ---"
+setup_worktree
+set_project_version "1.1.0"
+set_readme_pgagroal_pin "2.0.2"
+# DOCKER_HUB.md still references 1.0.1, not the new 1.1.0
+set_dockerhub_project_pin "1.0.1"
+write_changelog <<'EOF'
+# Changelog
+
+## [1.1.0] - 2026-04-29
+
+Class: feature
+
+### Added
+
+- thing.
+EOF
+git -C "${WORKDIR}" -c user.email=t@t -c user.name=t commit -q -am fixture
+run_check
+assert_exit "exit 1" 1 "${RC}"
+assert_contains "F8 cited" "${OUT}" "F8"
+cleanup_worktree
+
+# ── results ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+
+if [[ "${FAIL}" -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Implements **Gate F enforcement** for the project-release flow, realizing the Gate F acceptance cases from `specifications/project-release/spec.md`. Stacked on #17 (spec PR) — base will rebase to `main` once #17 merges.

Extends `scripts/prepare-release.sh` with checks F3–F8:
- **F3**: `CHANGELOG.md` has a dated `## [<version>] - YYYY-MM-DD` section matching `VERSION`
- **F4**: that section has `Class: <feature|fix|security|breaking-config>` as the first non-blank line
- **F5**: when `Class: breaking-config`, `docs/operations/migrations/<version>.md` exists
- **F6**: when `Class: security`, the section has a `### Security` subsection
- **F7**: `README.md` "Pinned versions" pgagroal row matches the Dockerfile pin
- **F8**: `DOCKER_HUB.md` references `elevarq/pgagroal:<project-version>`

Adds a 26-case test suite at `test/release-checks/test-prepare-release.sh` covering AC-08, AC-09, AC-10/10b/10c, AC-11/11b, AC-12/12b, AC-28, AC-29 from `specifications/project-release/acceptance-cases.md`. Tests use a tmp-worktree fixture pattern matching `test/refresh/test-refresh.sh`.

Backfills the 1.0.1 changelog section with `Class: fix` so `make release-check` continues to pass on `main` today. Historical sections (1.0.0 and earlier) are intentionally not backfilled — F4 only validates the section matching the current `VERSION`.

## Verification

- `make release-check` on the branch → F3-F8 all `OK` (pre-existing WARNs are feature-branch state, not gate failures)
- `make test-release-checks` → **26 passed, 0 failed**
- `make test-refresh` → **34 passed, 0 failed** (no regression)
- `shellcheck -S warning scripts/prepare-release.sh test/release-checks/test-prepare-release.sh` → clean
- `trivy fs --scanners secret .` → no findings

## Out of scope

- Wiring `make release-check` into `.github/workflows/container-ci.yml` — `prepare-release.sh` is a pre-tag local check today; CI integration is a separate concern with its own spec exercise.
- Backfilling `Class:` on changelog sections older than 1.0.1.
- Gates B (lint), D (supply chain), E (artifact) workflow enforcement — separate PRs.

## Test plan

- [ ] Review F4 grammar: `Class: <value>` as first non-blank line under the version heading — does this satisfy the convention you wanted, or should I tighten/relax (e.g. allow leading whitespace, allow a different field name)?
- [ ] Review the 1.0.1 backfill — is `Class: fix` the right characterization, or should it be `Class: feature` (since 1.0.1 also added `make test-docker-restart` and a gitleaks workflow)?
- [ ] Confirm `make test-release-checks` is the right Makefile target name (mirrors `test-refresh`).
- [ ] Stack: this targets `spec/project-release-flow`. Do you want me to flip the base to `main` once #17 merges?

🤖 Generated with [Claude Code](https://claude.com/claude-code)