### PR TITLE
docs: refresh stale 1.0.1 / 2.0.2 references after v1.1.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,8 +24,8 @@ What you expected to happen.
 
 ## Environment
 
-- pgagroal container version: (e.g. 2.0.2)
-- Project version: (e.g. 0.1.0)
+- pgagroal container version: (e.g. 2.1.0)
+- Project version: (e.g. 1.1.0)
 - Deployment method: Docker / Helm / docker-compose
 - Kubernetes version (if applicable):
 - Platform: (e.g. EKS, local Docker Desktop)

--- a/.github/workflows/container-ci.yml
+++ b/.github/workflows/container-ci.yml
@@ -127,7 +127,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Build image
-        run: docker build -t pgagroal:2.0.2 .
+        run: docker build -t pgagroal:2.1.0 .
 
       - name: Run integration test
         run: bash test/integration/container-start-test.sh
@@ -140,7 +140,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Build image
-        run: docker build -t pgagroal:2.0.2 .
+        run: docker build -t pgagroal:2.1.0 .
 
       - name: Run backend restart test
         run: bash test/resilience/backend-restart-test.sh

--- a/DOCKER_HUB.md
+++ b/DOCKER_HUB.md
@@ -66,8 +66,8 @@ Tags follow the project version in [VERSION](https://github.com/Elevarq/pgAgroal
 
 | Tag | Meaning |
 |---|---|
-| `1.0.1` | Exact release — pin this in production |
-| `1.0` | Latest patch of the 1.0 line |
+| `1.1.0` | Exact release — pin this in production |
+| `1.1` | Latest patch of the 1.1 line |
 | `latest` | Most recent stable release — convenience only |
 
 Only CI publishes tags. `latest` is a multi-arch manifest updated on every release.

--- a/README.md
+++ b/README.md
@@ -145,14 +145,14 @@ In production, pin a version tag rather than `latest`:
 ```yaml
 image:
   repository: elevarq/pgagroal
-  tag: "1.0.1"
+  tag: "1.1.0"
   pullPolicy: IfNotPresent
 ```
 
 Verify the pinned image before rolling out:
 
 ```bash
-cosign verify elevarq/pgagroal:1.0.1 \
+cosign verify elevarq/pgagroal:1.1.0 \
   --certificate-identity-regexp "https://github.com/Elevarq/pgAgroal/.*" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/docs/deployment/eks-deployment.md
+++ b/docs/deployment/eks-deployment.md
@@ -27,8 +27,8 @@ REGISTRY="${ACCOUNT}.dkr.ecr.${REGION}.amazonaws.com"
 aws ecr get-login-password --region ${REGION} \
   | docker login --username AWS --password-stdin ${REGISTRY}
 
-docker tag pgagroal:2.0.2 ${REGISTRY}/pgagroal:2.0.2
-docker push ${REGISTRY}/pgagroal:2.0.2
+docker tag pgagroal:2.1.0 ${REGISTRY}/pgagroal:2.1.0
+docker push ${REGISTRY}/pgagroal:2.1.0
 ```
 
 ## 2. Create the Credentials Secret

--- a/docs/deployment/first-client-deployment.md
+++ b/docs/deployment/first-client-deployment.md
@@ -9,7 +9,7 @@ Before starting, confirm:
 - [ ] `kubectl` is configured and pointing at the target EKS cluster
 - [ ] `helm` v3 is installed locally
 - [ ] The pgagroal container image has been pushed to ECR (see [docs/eks-deployment.md](eks-deployment.md) steps 1-2)
-- [ ] You know the ECR image URI and tag (e.g. `123456789012.dkr.ecr.eu-west-1.amazonaws.com/pgagroal:2.0.2`)
+- [ ] You know the ECR image URI and tag (e.g. `123456789012.dkr.ecr.eu-west-1.amazonaws.com/pgagroal:2.1.0`)
 - [ ] You know the PostgreSQL/RDS endpoint and port
 - [ ] You have the PostgreSQL credentials (username + password)
 - [ ] EKS nodes can reach the RDS instance (Security Groups, VPC peering, etc.)

--- a/docs/deployment/post-deployment-verification.md
+++ b/docs/deployment/post-deployment-verification.md
@@ -12,7 +12,7 @@ Confirm Helm recorded the release:
 helm list -n pgagroal
 ```
 
-Expected: `STATUS = deployed`, chart version matches `0.1.0`, app version matches `2.0.2`.
+Expected: `STATUS = deployed`, chart version matches `1.1.0`, app version matches `2.1.0`.
 
 Check the deployed image:
 
@@ -20,7 +20,7 @@ Check the deployed image:
 kubectl -n pgagroal get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.containers[0].image}{"\n"}{end}'
 ```
 
-Expected: every pod shows your ECR URI with tag `2.0.2`.
+Expected: every pod shows your ECR URI with tag `2.1.0`.
 
 ## 2. Pod readiness
 
@@ -107,7 +107,7 @@ Check every replica has a clean startup:
 kubectl -n pgagroal logs -l app.kubernetes.io/name=pgagroal --tail=30
 ```
 
-Expected: `pgagroal: 2.0.2 started on *:6432` with no `ERROR` or `FATAL` lines.
+Expected: `pgagroal: 2.1.0 started on *:6432` with no `ERROR` or `FATAL` lines.
 
 Search for errors:
 

--- a/helm/pgagroal/values-client-example.yaml
+++ b/helm/pgagroal/values-client-example.yaml
@@ -13,7 +13,7 @@
 # ---------------------------------------------------------------------------
 image:
   repository: "CHANGEME.dkr.ecr.eu-west-1.amazonaws.com/pgagroal"  # CHANGEME: ECR URI
-  tag: "2.0.2"
+  tag: "2.1.0"
   pullPolicy: IfNotPresent
 
 # ---------------------------------------------------------------------------

--- a/helm/pgagroal/values-eks-example.yaml
+++ b/helm/pgagroal/values-eks-example.yaml
@@ -7,15 +7,15 @@
 # Prerequisites:
 #   - Push image to ECR:
 #       aws ecr get-login-password | docker login --username AWS --password-stdin <ACCOUNT>.dkr.ecr.<REGION>.amazonaws.com
-#       docker tag pgagroal:2.0.2 <ACCOUNT>.dkr.ecr.<REGION>.amazonaws.com/pgagroal:2.0.2
-#       docker push <ACCOUNT>.dkr.ecr.<REGION>.amazonaws.com/pgagroal:2.0.2
+#       docker tag pgagroal:2.1.0 <ACCOUNT>.dkr.ecr.<REGION>.amazonaws.com/pgagroal:2.1.0
+#       docker push <ACCOUNT>.dkr.ecr.<REGION>.amazonaws.com/pgagroal:2.1.0
 #   - Create the external secret or use credentials.create with sealed-secrets
 
 replicaCount: 3
 
 image:
   repository: "123456789012.dkr.ecr.eu-west-1.amazonaws.com/pgagroal"
-  tag: "2.0.2"
+  tag: "2.1.0"
   pullPolicy: IfNotPresent
 
 serviceAccount:


### PR DESCRIPTION
## Summary

Found by manual audit of the repo for `1.0.1` and `2.0.2` after the v1.1.0 release. Several copy-pastable examples and CI plumbing references didn't move when the release shipped — users following them would pin to outdated images, and CI logs were labeling builds with the previous pgagroal version.

## Changes

**Project version `1.0.1` → `1.1.0`** (2 files):
- `README.md` — Helm `tag:` example and the `cosign verify` snippet in the "Image Verification" section
- `DOCKER_HUB.md` — "Versioning and tags" table: `1.0.1` → `1.1.0` and `1.0` → `1.1` to reflect the current latest stable line

**pgagroal version `2.0.2` → `2.1.0`** (7 files):
- `.github/workflows/container-ci.yml` — two `docker build -t pgagroal:2.0.2 .` steps
- `helm/pgagroal/values-eks-example.yaml` — three refs (ECR push commands + `image.tag`)
- `helm/pgagroal/values-client-example.yaml` — `image.tag`
- `docs/deployment/eks-deployment.md` — ECR push commands
- `docs/deployment/first-client-deployment.md` — example ECR URI
- `docs/deployment/post-deployment-verification.md` — three expected-output checks; also bumped chart-version expectation `0.1.0` → `1.1.0` (extremely stale — predates the 1.x line)
- `.github/ISSUE_TEMPLATE/bug_report.md` — example values

**Intentionally NOT changed** (audit found these but they are correct as-is):
- `CHANGELOG.md` historical sections — they document past releases
- `specifications/project-release/acceptance-cases.md`, `release-refresh/acceptance-cases.md` — versioned examples in spec scenarios (mismatch demonstrations, RC/stable narratives)
- `test/release-checks/test-prepare-release.sh` — AC-29 fixture deliberately uses stale `1.0.1` to exercise F8's stale-detection path
- `docs/operations/migrations/1.1.0.md` — the "roll back to `elevarq/pgagroal:1.0.1`" step is operationally correct: `1.0.1` IS the rollback target
- `docs/release/release-checklist.md` and `docs/release/monthly-refresh.md` — illustrative narrative examples

## Why no version bump / changelog entry

This is post-release docs hygiene, not a behavior change. The next real release that bumps `VERSION` will pick it up. `make release-check` confirms F1–F8 still pass on the unchanged `1.1.0` state.

## Verification

- `make release-check` → F1–F8 all `OK`
- `helm lint helm/pgagroal/` → clean
- Final audit: `grep -rnE "1\.0\.1\|2\.0\.2"` returns only intentional historical/spec/fixture matches

## Notes

- `container-ci.yml` build tags (`pgagroal:2.0.2 → 2.1.0`) are functionally redundant — the test scripts re-build as `pgagroal:test` immediately. A cleaner improvement is to derive the tag from `Dockerfile` ARG so it never goes stale; out of scope for this docs-fix PR.
- An F-gate enhancement to catch these (a doc grep for `elevarq/pgagroal:<version-other-than-current>` in README/DOCKER_HUB.md examples) would be a worthwhile spec amendment in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)