### PR TITLE
release: add Gate F9 — block stale image refs in user-facing docs

### DIFF
--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -166,6 +166,27 @@ if [[ -f DOCKER_HUB.md ]]; then
     fi
 fi
 
+# F9: README.md and DOCKER_HUB.md must not contain stale elevarq/pgagroal:<old>
+# refs (any image-tag reference whose version differs from current VERSION).
+# Spec: specifications/project-release/spec.md (ACTIVE), Gate F.
+F9_FAIL=0
+for f9_file in README.md DOCKER_HUB.md; do
+    [[ -f "${f9_file}" ]] || continue
+    while IFS=: read -r f9_line f9_match; do
+        f9_ver=${f9_match#*elevarq/pgagroal:}
+        f9_ver=${f9_ver%%[^0-9.rc-]*}
+        if [[ -n "${f9_ver}" ]] && [[ "${f9_ver}" != "${PROJECT_VERSION}" ]]; then
+            warn "F9: ${f9_file}:${f9_line} contains stale image ref elevarq/pgagroal:${f9_ver} (expected ${PROJECT_VERSION})"
+            F9_FAIL=1
+        fi
+    done < <(grep -nEo 'elevarq/pgagroal:[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?' "${f9_file}" 2>/dev/null || true)
+done
+if [[ "${F9_FAIL}" -eq 0 ]]; then
+    ok "F9: README.md and DOCKER_HUB.md only reference elevarq/pgagroal:${PROJECT_VERSION}"
+else
+    ERRORS=$((ERRORS + 1))
+fi
+
 echo ""
 
 if [[ "${ERRORS}" -gt 0 ]]; then

--- a/specifications/project-release/acceptance-cases.md
+++ b/specifications/project-release/acceptance-cases.md
@@ -300,7 +300,39 @@ and re-pushes `v1.1.0`
 - `DOCKER_HUB.md` does not contain references to the previous version
   (`1.0.1`) in those snippets
 
-## AC-30: Docker Hub overview synchronized post-release  `[postcondition]`
+## AC-30: F9 — README + DOCKER_HUB.md only reference current version  `[gate-F]`
+
+**Given**: `VERSION` is `1.1.0`; `README.md` and `DOCKER_HUB.md` contain
+`elevarq/pgagroal:1.1.0` references and no other version pins
+**When**: Gate F enforcement runs
+**Then**:
+- F9 passes (no stale references found)
+
+## AC-31: F9 — stale reference in README.md  `[gate-F] [failure]`
+
+**Given**: `VERSION` is `1.1.0`; `README.md` contains
+`elevarq/pgagroal:1.0.1` somewhere outside an explicitly-historical
+section (e.g. a Helm tag example or a cosign-verify snippet)
+**When**: Gate F enforcement runs
+**Then**:
+- Exit code non-zero
+- Error message cites F9
+- Error message names the stale version (`1.0.1`) and the file
+  (`README.md`)
+
+## AC-32: F9 — stale reference in DOCKER_HUB.md  `[gate-F] [failure]`
+
+**Given**: `VERSION` is `1.1.0`; `DOCKER_HUB.md` contains
+`elevarq/pgagroal:1.0.1` (e.g. a leftover row in the "Versioning and
+tags" table or an unstaffed example)
+**When**: Gate F enforcement runs
+**Then**:
+- Exit code non-zero
+- Error message cites F9
+- Error message names the stale version (`1.0.1`) and the file
+  (`DOCKER_HUB.md`)
+
+## AC-33: Docker Hub overview synchronized post-release  `[postcondition]`
 
 **Given**: a stable release `v1.1.0` has been published and merged to main
 **When**: `.github/workflows/dockerhub-description.yml` completes
@@ -329,7 +361,7 @@ every acceptance case references at least one spec element.
 | Gate C | AC-14, AC-15, AC-16 |
 | Gate D | AC-13, AC-18 |
 | Gate E | AC-19, AC-21, AC-22, AC-20 |
-| Gate F | AC-01..AC-04, AC-08..AC-12b, AC-28, AC-29 |
-| Postconditions Q1–Q9 | AC-19..AC-25, AC-30 |
+| Gate F | AC-01..AC-04, AC-08..AC-12b, AC-28..AC-32 |
+| Postconditions Q1–Q9 | AC-19..AC-25, AC-33 |
 | Failure: retraction | AC-27 |
 | Failure: idempotent push | AC-26 |

--- a/specifications/project-release/spec.md
+++ b/specifications/project-release/spec.md
@@ -169,8 +169,26 @@ release.
 | F6 | If `Class: security`: `### Security` subsection present in changelog |
 | F7 | `README.md` "Pinned versions" table reflects current pinned versions |
 | F8 | `DOCKER_HUB.md` quick-start and verification snippets reference the release version |
+| F9 | `README.md` and `DOCKER_HUB.md` contain no `elevarq/pgagroal:<X.Y.Z>` reference where `<X.Y.Z>` differs from the current `VERSION`; stale tags in user-facing examples are blocked |
 
-`make prepare-release` runs F1–F2 today. F3–F8 are added by this spec.
+`make prepare-release` runs F1–F2 today. F3–F9 are added by this spec.
+
+F9 specifically guards against the failure mode where post-release docs
+hygiene drifts: an old version tag remains in a copy-pasteable example
+because nothing checked for it. F8 ensures the *current* version
+*appears*; F9 ensures *no other* version *appears*. The two are
+complementary.
+
+The check applies only to `README.md` and `DOCKER_HUB.md` because
+those are the top-level user-facing surfaces. It does not apply to:
+
+- `CHANGELOG.md` (history is supposed to mention old versions)
+- `docs/operations/migrations/<version>.md` (rollback steps
+  legitimately reference older versions)
+- `specifications/` (versioned examples in spec narratives)
+- `test/release-checks/` (fixtures deliberately use stale values)
+- `docs/release/release-checklist.md`, `docs/release/monthly-refresh.md`
+  (illustrative narrative examples)
 
 ## Postconditions
 
@@ -236,6 +254,7 @@ clear human / automation handoff.
 | Phase 1 | `Class:` field missing or invalid in the dated changelog section | F4 fails |
 | Phase 1 | `Class: breaking-config` declared but migration doc missing | F5 fails |
 | Phase 1 | `Class: security` declared but `### Security` subsection missing | F6 fails |
+| Phase 1 | `README.md` or `DOCKER_HUB.md` contains a stale `elevarq/pgagroal:<old>` reference | F9 fails |
 | Phase 2 | Any of Gates A–F fail in CI | publish workflow exits non-zero; tag remains but no image is published; remediate by deleting the tag (`git push origin :v<X.Y.Z>`), fixing on a new branch, and re-tagging |
 | Phase 2 | CRITICAL CVE found by Trivy | STOP per parent CLAUDE.md severity rule |
 | Phase 2 | Any gitleaks finding | STOP — secret rotation required before retag |

--- a/test/release-checks/test-prepare-release.sh
+++ b/test/release-checks/test-prepare-release.sh
@@ -62,6 +62,15 @@ set_dockerhub_project_pin() {
     sed -i'' -e "s|elevarq/pgagroal:[0-9][0-9.]*|elevarq/pgagroal:${v}|g" "${WORKDIR}/DOCKER_HUB.md"
 }
 
+# Normalize all elevarq/pgagroal:<X.Y.Z> refs in README.md to the given version.
+# Required by F9: tests that don't run at the source's current VERSION must
+# bring the README's image-tag examples in line, otherwise F9 correctly
+# flags them as stale.
+set_readme_image_refs() {
+    local v="$1"
+    sed -i'' -e "s|elevarq/pgagroal:[0-9][0-9.]*\(-rc[0-9]*\)\{0,1\}|elevarq/pgagroal:${v}|g" "${WORKDIR}/README.md"
+}
+
 run_check() {
     set +e
     OUT=$(cd "${WORKDIR}" && bash scripts/prepare-release.sh --check-only 2>&1)
@@ -256,7 +265,10 @@ Class: breaking-config
 
 - Vault rotation required.
 EOF
-# NB: migration doc deliberately not created
+# Source has docs/operations/migrations/1.1.0.md (from the real v1.1.0
+# release); the fixture must explicitly remove it to recreate the
+# "no migration doc" failure mode F5 guards against.
+rm -f "${WORKDIR}/docs/operations/migrations/1.1.0.md"
 git -C "${WORKDIR}" -c user.email=t@t -c user.name=t commit -q -am fixture
 run_check
 assert_exit "exit 1" 1 "${RC}"
@@ -271,6 +283,7 @@ echo "--- AC-11b: non-breaking does not require migration doc ---"
 setup_worktree
 set_project_version "1.0.2"
 set_readme_pgagroal_pin "${BASELINE_PGAGROAL}"
+set_readme_image_refs "1.0.2"
 set_dockerhub_project_pin "1.0.2"
 write_changelog <<'EOF'
 # Changelog
@@ -321,6 +334,7 @@ echo "--- AC-12b: fix class has no extra requirement ---"
 setup_worktree
 set_project_version "1.0.2"
 set_readme_pgagroal_pin "${BASELINE_PGAGROAL}"
+set_readme_image_refs "1.0.2"
 set_dockerhub_project_pin "1.0.2"
 write_changelog <<'EOF'
 # Changelog
@@ -390,6 +404,96 @@ git -C "${WORKDIR}" -c user.email=t@t -c user.name=t commit -q -am fixture
 run_check
 assert_exit "exit 1" 1 "${RC}"
 assert_contains "F8 cited" "${OUT}" "F8"
+cleanup_worktree
+
+# --------------------------------------------------------------------------
+# AC-30: F9 — README + DOCKER_HUB only reference current VERSION  [gate-F]
+# --------------------------------------------------------------------------
+echo "--- AC-30: F9 happy — no stale image refs ---"
+setup_worktree
+set_project_version "1.1.0"
+set_readme_pgagroal_pin "${BASELINE_PGAGROAL}"
+set_dockerhub_project_pin "1.1.0"
+# Normalize README so any pre-existing image refs are at 1.1.0 too.
+sed -i'' -e 's|elevarq/pgagroal:[0-9][0-9.]*|elevarq/pgagroal:1.1.0|g' "${WORKDIR}/README.md"
+write_changelog <<'EOF'
+# Changelog
+
+## [1.1.0] - 2026-04-29
+
+Class: feature
+
+### Added
+
+- thing.
+EOF
+git -C "${WORKDIR}" -c user.email=t@t -c user.name=t commit -q -am fixture
+run_check
+assert_exit "exit 0" 0 "${RC}"
+assert_contains "F9 ok" "${OUT}" "F9"
+cleanup_worktree
+
+# --------------------------------------------------------------------------
+# AC-31: F9 — stale image ref in README.md  [gate-F] [failure]
+# --------------------------------------------------------------------------
+echo "--- AC-31: F9 stale ref in README.md ---"
+setup_worktree
+set_project_version "1.1.0"
+set_readme_pgagroal_pin "${BASELINE_PGAGROAL}"
+set_dockerhub_project_pin "1.1.0"
+sed -i'' -e 's|elevarq/pgagroal:[0-9][0-9.]*|elevarq/pgagroal:1.1.0|g' "${WORKDIR}/README.md"
+# Inject a stale ref (mimics the real-world bug PR #22 fixed)
+echo "" >> "${WORKDIR}/README.md"
+echo "Old example: elevarq/pgagroal:1.0.1" >> "${WORKDIR}/README.md"
+write_changelog <<'EOF'
+# Changelog
+
+## [1.1.0] - 2026-04-29
+
+Class: feature
+
+### Added
+
+- thing.
+EOF
+git -C "${WORKDIR}" -c user.email=t@t -c user.name=t commit -q -am fixture
+run_check
+assert_exit "exit 1" 1 "${RC}"
+assert_contains "F9 cited" "${OUT}" "F9"
+assert_contains "names stale version" "${OUT}" "1\\.0\\.1"
+assert_contains "names file" "${OUT}" "README\\.md"
+cleanup_worktree
+
+# --------------------------------------------------------------------------
+# AC-32: F9 — stale image ref in DOCKER_HUB.md  [gate-F] [failure]
+# --------------------------------------------------------------------------
+echo "--- AC-32: F9 stale ref in DOCKER_HUB.md ---"
+setup_worktree
+set_project_version "1.1.0"
+set_readme_pgagroal_pin "${BASELINE_PGAGROAL}"
+sed -i'' -e 's|elevarq/pgagroal:[0-9][0-9.]*|elevarq/pgagroal:1.1.0|g' "${WORKDIR}/README.md"
+set_dockerhub_project_pin "1.1.0"
+# Inject a leftover stale ref (mimics the "Versioning and tags" table row
+# that PR #22 had to fix)
+echo "" >> "${WORKDIR}/DOCKER_HUB.md"
+echo "Older release: elevarq/pgagroal:1.0.1 — pin if you need the 1.0 line" >> "${WORKDIR}/DOCKER_HUB.md"
+write_changelog <<'EOF'
+# Changelog
+
+## [1.1.0] - 2026-04-29
+
+Class: feature
+
+### Added
+
+- thing.
+EOF
+git -C "${WORKDIR}" -c user.email=t@t -c user.name=t commit -q -am fixture
+run_check
+assert_exit "exit 1" 1 "${RC}"
+assert_contains "F9 cited" "${OUT}" "F9"
+assert_contains "names stale version" "${OUT}" "1\\.0\\.1"
+assert_contains "names file" "${OUT}" "DOCKER_HUB\\.md"
 cleanup_worktree
 
 # ── results ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Tightens release hygiene with a new **Gate F9** that scans `README.md` and `DOCKER_HUB.md` for any `elevarq/pgagroal:<X.Y.Z>` reference whose version differs from current `VERSION`.

> F8 ensures the *current* version *appears*. F9 ensures *no other* version *appears*. The two are complementary.

This closes the exact failure mode #22 had to fix manually: stale Helm tag and cosign-verify examples in README, plus a stale row in DOCKER_HUB.md's "Versioning and tags" table — all of which sat through the v1.1.0 publish unflagged because no gate looked for them.

## STDD trace

- **Spec** — `specifications/project-release/spec.md` Gate F: new F9 row with explicit excluded-paths list
- **Acceptance cases** — `specifications/project-release/acceptance-cases.md`: AC-30 (F9 happy), AC-31 (F9 stale-README), AC-32 (F9 stale-DOCKER_HUB); existing post-condition case renumbered AC-30 → AC-33; coverage map updated
- **Tests** — `test/release-checks/test-prepare-release.sh`: 3 new test cases driving the new check, plus 3 fixture fixes for pre-existing tests that broke when v1.1.0 shipped (AC-11 inherited the migration doc; AC-11b/AC-12b had source README image refs that don't match their test VERSION)
- **Implementation** — `scripts/prepare-release.sh`: F9 block grepping for `elevarq/pgagroal:<X.Y.Z>(-rcN)?` in both files, comparing each to `${PROJECT_VERSION}`

## Verification

- `make test-release-checks` → **36/36** (was 26/26 before F9)
- `make test-refresh` → **34/34** (no regression)
- `make release-check` on real repo → F1–F9 all `OK`
- `shellcheck` → clean

## Why no VERSION bump / CHANGELOG entry

This is a tooling enhancement; the released artifact is unchanged. The next release that bumps `VERSION` will pick up F9 automatically and can mention it in its changelog.

## Out of scope (could be follow-ups)

- Extend F9-style stale checks to `helm/pgagroal/values-*-example.yaml` (`image.tag`) — the helm sample values had stale `2.0.2` references in the same drift, fixed in #22 but not gated.
- A `--auto-fix` flag on `prepare-release.sh` that bumps refs in place when F9 fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)