### PR TITLE
docs: community-health parity — CODE_OF_CONDUCT, GOVERNANCE, CODEOWNERS fix

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,8 @@
 # Default owners for the entire repository
-* @Elevarq/infrastructure
+* @fheikens
 
 # Helm chart
-helm/ @Elevarq/infrastructure
+helm/ @fheikens
 
 # CI pipeline
-.github/ @Elevarq/infrastructure
+.github/ @fheikens

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Code of Conduct
+
+## Our commitment
+
+We are committed to providing a welcoming and constructive environment
+for everyone who participates in the pgAgroal project, regardless of
+experience level, background, or identity.
+
+## Expected behavior
+
+- Be respectful and considerate in all interactions
+- Provide constructive feedback focused on the work, not the person
+- Accept differing viewpoints gracefully
+- Focus on what is best for the project and community
+
+## Unacceptable behavior
+
+- Personal attacks, insults, or derogatory comments
+- Harassment of any kind, public or private
+- Publishing others' private information without permission
+- Any conduct that would be considered inappropriate in a professional
+  setting
+
+## Scope
+
+This code of conduct applies to all project spaces: GitHub issues,
+pull requests, discussions, and any other communication channels
+associated with pgAgroal.
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported to the project
+maintainers at conduct@elevarq.com. All reports will be reviewed
+and investigated. Maintainers reserve the right to remove, edit, or
+reject contributions that violate this code of conduct.
+
+## Attribution
+
+This code of conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org/), version
+2.1.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,37 @@
+# Governance
+
+## Project ownership
+
+pgAgroal is maintained by [Elevarq](https://elevarq.com). The project is
+open source under the BSD-3-Clause license.
+
+## Decision making
+
+Architectural and strategic decisions are made by the Elevarq core team.
+Community input is welcome via GitHub issues and pull requests.
+
+## Contribution process
+
+1. Open an issue describing the proposed change
+2. Discuss the approach with maintainers
+3. Submit a pull request following [CONTRIBUTING.md](CONTRIBUTING.md)
+4. Maintainers review and merge or request changes
+
+## Scope boundary
+
+This repository packages [pgagroal](https://github.com/pgagroal/pgagroal)
+as a production-grade container and Helm chart. Its scope is the
+container image, the Helm chart, deployment configuration, and the
+supporting build/release tooling.
+
+It is **not** the home for changes to pgagroal itself. Bugs and features
+in the pooler belong upstream at the
+[pgagroal project](https://github.com/pgagroal/pgagroal); security issues
+in pgagroal should follow that project's disclosure process. Contributions
+here that cross into upstream territory will be redirected accordingly.
+
+## Code of conduct
+
+We expect all participants to be respectful and constructive. Harassment,
+discrimination, and abusive behavior are not tolerated. See
+[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
## Summary

Brings pgAgroal toward community-health parity with Arq-Signals.

- **Add `CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1, same as Arq-Signals (`conduct@elevarq.com`).
- **Add `GOVERNANCE.md`** — with the container-packaging scope boundary so pooler bugs/features are routed upstream to the [pgagroal project](https://github.com/pgagroal/pgagroal).
- **Fix `CODEOWNERS`** — it referenced `@Elevarq/infrastructure`, **a team that does not exist**, so review routing was silently inert and GitHub flagged an unknown owner. Now points at a real owner (`@fheikens`) until/unless a team is created.

## Not in this PR (tracked on #28)

Issue-template migration from legacy markdown (`bug_report.md` / `feature_request.md`) to structured YAML forms — that changes issue UX and deserves its own focused review. The Arq-Signals forms reference a `docs/ESTIMATION.md` that pgAgroal lacks, so the forms need adapting rather than copying.

Documentation-only.

Refs #28