### PR TITLE
docs(readme): add CI status badge, align license badge style

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Production-grade Docker container and Helm chart for [pgagroal](https://github.c
 
 From [Elevarq](https://elevarq.com) — PostgreSQL tools for engineering teams.
 
-[![License: BSD-3-Clause](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](LICENSE)
+[![CI](https://github.com/Elevarq/pgAgroal/actions/workflows/container-ci.yml/badge.svg)](https://github.com/Elevarq/pgAgroal/actions/workflows/container-ci.yml)
+[![License: BSD-3-Clause](https://img.shields.io/badge/License-BSD--3--Clause-blue.svg)](LICENSE)
 
 ## Contents
 


### PR DESCRIPTION
## Summary

Adds a CI status badge (`container-ci.yml`) and aligns the license badge style with Arq-Signals, so pgAgroal gives the same at-a-glance trust signal.

Deliberately **no OpenSSF Scorecard badge**: no Scorecard workflow runs in this repo yet, and per #29's acceptance criteria a badge for a non-existent check would be misleading. Adding Scorecard can be a follow-up.

Badge URLs use canonical `Elevarq/pgAgroal` casing. Documentation-only.

`closes #29`