### PR TITLE
ci(publish): mirror the container image to GHCR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: write   # create GitHub Release
   id-token: write   # OIDC token for Sigstore signing + provenance
+  packages: write   # push image to GHCR (ghcr.io/elevarq/pgagroal)
 
 jobs:
   # ── Gate A.1 + F — tag/VERSION consistency, changelog present ─────────
@@ -150,7 +151,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: elevarq/pgagroal
+          images: |
+            elevarq/pgagroal
+            ghcr.io/elevarq/pgagroal
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -167,6 +170,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         id: build
@@ -224,7 +234,8 @@ jobs:
 
           ## Supply chain
 
-          - Image: \`elevarq/pgagroal:${VERSION}\`
+          - Image (Docker Hub): \`docker.io/elevarq/pgagroal:${VERSION}\`
+          - Image (GHCR): \`ghcr.io/elevarq/pgagroal:${VERSION}\`
           - Digest: \`${DIGEST}\`
           - Architectures: linux/amd64, linux/arm64
           - Signed with [cosign](https://github.com/sigstore/cosign) (keyless, GitHub OIDC)

--- a/specifications/project-release/spec.md
+++ b/specifications/project-release/spec.md
@@ -69,12 +69,15 @@ glance and gives Gate F a single deterministic field to validate.
 On success a project release produces:
 
 1. A signed git tag `v<X.Y.Z>` on `main` of `Elevarq/pgAgroal`.
-2. A multi-arch container image at `elevarq/pgagroal:<X.Y.Z>` covering
-   `linux/amd64` and `linux/arm64`.
-3. Image tags on Docker Hub (per `docs/release/release-checklist.md`):
+2. A multi-arch container image covering `linux/amd64` and `linux/arm64`,
+   published to **both** registries from a single build:
+   - Docker Hub: `docker.io/elevarq/pgagroal:<X.Y.Z>` (reach)
+   - GHCR: `ghcr.io/elevarq/pgagroal:<X.Y.Z>` (GitHub-native discoverability)
+3. The same tag set on both registries (per `docs/release/release-checklist.md`):
    - Stable: `<X.Y.Z>`, `<X.Y>`, `latest`
    - RC: `<X.Y.Z>-rc<N>` only — must not update `<X.Y>` or `latest`
-4. A cosign keyless signature on the published image (GitHub OIDC issuer).
+4. A cosign keyless signature on every published tag (GitHub OIDC issuer),
+   across both registries.
 5. An SBOM attestation (SPDX-JSON) attached to the image.
 6. A SLSA provenance attestation (`mode=max`) attached to the image.
 7. A GitHub Release object for the tag, with body sourced from the


### PR DESCRIPTION
## Summary

Publishes the pgAgroal image to **`ghcr.io/elevarq/pgagroal`** alongside Docker Hub, from a single build — GitHub-native discoverability + parity with Arq-Signals. Docker Hub stays the reach registry.

- `metadata-action` now emits tags for both `elevarq/pgagroal` and `ghcr.io/elevarq/pgagroal`.
- Added `packages: write` + a GHCR login step using `GITHUB_TOKEN`.
- The **existing cosign sign loop already iterates all tags**, so both registries' tags are signed; SBOM + SLSA provenance come from the single `build-push` (`sbom: true`, `provenance: mode=max`) and attach to both.
- Release notes reference both image refs.
- `specifications/project-release/spec.md` Outputs updated to list both registries (STDD: spec before pipeline).

## Validation

- `actionlint` passes. (Repo has no yamllint gate.)
- No pipeline behaviour runs until the next `v*` tag — safe to review without a release.

## Hand-off note

The new GHCR package is created **private** on first publish; it must be flipped public + linked to the repo in the UI afterward (same as the arq-signals GHCR flip).

`closes #34`