### PR TITLE
fix(security): apply Debian security updates in runtime image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ Class: feature
 - Release tooling: new Gate F9 blocks stale image references in user
   docs; added a local container security gate.
 
+### Security
+
+- Apply Debian security updates in the runtime image so CVE fixes from
+  bookworm-security (e.g. libgnutls30 `deb12u7`, libcap2 `deb12u3`) are
+  included — the pinned base-image snapshot does not bake these in.
+
 ### CI
 
 - Bump `azure/setup-helm` 4 → 5 and `aquasecurity/trivy-action`

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,13 @@ LABEL maintainer="elevarq" \
       org.opencontainers.image.source="https://github.com/pgagroal/pgagroal" \
       org.opencontainers.image.version="${PGAGROAL_VERSION}"
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Pull Debian security updates on top of the pinned base. Debian publishes
+# CVE fixes (e.g. libgnutls30 deb12u7, libcap2 deb12u3) to bookworm-security,
+# which the dated base-image snapshots do not bake in — so a security
+# upgrade is required to ship a CVE-clean runtime. DL3005 is intentionally
+# ignored here for exactly that reason.
+# hadolint ignore=DL3005
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
         libssl3 \
         zlib1g \
         libbz2-1.0 \


### PR DESCRIPTION
The v1.2.0 publish correctly **blocked at Gate C** — the runtime image carried fixable CRITICAL/HIGH CVEs:
- libgnutls30: CVE-2026-33845, CVE-2026-42010 (CRITICAL) + 3 HIGH → fixed in `deb12u7`
- libcap2: CVE-2026-4878 (HIGH) → fixed in `deb12u3`

Debian publishes these via **bookworm-security**, which the dated base-image snapshots don't bake in (verified: even `bookworm-20260518-slim` still ships libgnutls30 `deb12u6`). Bumping the pin can't fix it — so the runtime stage now runs `apt-get upgrade` to pull the security patches (hadolint DL3005 ignored with rationale).

**Verified locally**: built the image and Trivy-scanned it — clean of the fixable CRITICAL/HIGH findings. This unblocks the v1.2.0 release.

Refs #30