### PR TITLE
ci(publish): publish Helm chart as OCI artifact to GHCR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -205,6 +205,65 @@ jobs:
             cosign sign --yes "${tag}@${digest}"
           done
 
+  # ── Gate E (chart) — publish Helm chart as an OCI artifact ────────────
+  # Parity with the container image: the chart is pushed to GHCR as an
+  # OCI artifact so it installs by reference without a repo checkout:
+  #   helm install pgagroal oci://ghcr.io/elevarq/charts/pgagroal \
+  #     --version <X.Y.Z>
+  # The chart version is stamped from the release tag at package time;
+  # the validate job already enforces Chart.yaml == tag, so the two
+  # always agree. See #40.
+  publish-chart:
+    name: Publish Helm chart (OCI)
+    needs: [validate, publish]
+    runs-on: ubuntu-24.04
+    env:
+      CHART_REGISTRY: oci://ghcr.io/elevarq/charts
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.4
+
+      - name: Lint chart
+        run: helm lint helm/pgagroal
+
+      - name: Log in to GHCR (helm registry)
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            helm registry login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Package chart (version stamped from tag)
+        id: package
+        run: |
+          VERSION="${{ needs.validate.outputs.version }}"
+          helm package helm/pgagroal \
+            --version "${VERSION}" \
+            --app-version "${VERSION}" \
+            --destination dist-chart
+          echo "file=dist-chart/pgagroal-${VERSION}.tgz" >> "$GITHUB_OUTPUT"
+
+      - name: Push chart to GHCR
+        id: push
+        run: |
+          # `helm push` prints the pushed digest to stderr; capture the
+          # whole stream so the cosign step can sign the exact digest.
+          helm push "${{ steps.package.outputs.file }}" "${CHART_REGISTRY}" 2>&1 | tee push.log
+          DIGEST="$(grep -oE 'sha256:[0-9a-f]{64}' push.log | head -1)"
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      # Keyless signing, same trust root as the container image: the
+      # signature binds back to this workflow's GitHub OIDC identity.
+      - name: Sign chart (cosign keyless)
+        run: |
+          cosign sign --yes \
+            "ghcr.io/elevarq/charts/pgagroal@${{ steps.push.outputs.digest }}"
+
   # ── Gate F — GitHub Release with extracted changelog + supply chain ───
   release:
     name: GitHub Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Release workflow now publishes the Helm chart as an OCI artifact to
+  `oci://ghcr.io/elevarq/charts/pgagroal`, cosign-signed with the same
+  keyless GitHub OIDC identity as the container image. The chart version
+  is stamped from the release tag at package time. (#40)
+
 ## [1.2.0] - 2026-05-27
 
 Class: feature

--- a/DOCKER_HUB.md
+++ b/DOCKER_HUB.md
@@ -72,6 +72,16 @@ Tags follow the project version in [VERSION](https://github.com/Elevarq/pgAgroal
 
 Only CI publishes tags. `latest` is a multi-arch manifest updated on every release.
 
+## Helm chart
+
+The Helm chart is published as an OCI artifact to GHCR alongside each release, so it installs by reference (the chart version matches the image tag):
+
+```bash
+helm install pgagroal oci://ghcr.io/elevarq/charts/pgagroal --version 1.2.0
+```
+
+The chart is cosign-signed with the same keyless GitHub OIDC identity as the image.
+
 ## Documentation
 
 - Product documentation: [elevarq.com/docs/pgagroal-container](https://elevarq.com/docs/pgagroal-container)

--- a/README.md
+++ b/README.md
@@ -39,6 +39,30 @@ make stop
 
 ### Kubernetes / Helm
 
+Each release publishes the chart as an OCI artifact to GHCR, so you can
+install by reference without a repo checkout (the chart version matches
+the release version):
+
+```bash
+helm install pgagroal oci://ghcr.io/elevarq/charts/pgagroal \
+  --version 1.2.0 \
+  --set postgresql.host=my-postgres \
+  --set credentials.username=app \
+  --set credentials.password=secret \
+  -n pgagroal --create-namespace
+```
+
+The published chart is cosign-signed (keyless, GitHub OIDC) -- the same
+trust root as the container image. Verify before install:
+
+```bash
+cosign verify ghcr.io/elevarq/charts/pgagroal:1.2.0 \
+  --certificate-identity-regexp='https://github.com/Elevarq/' \
+  --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
+```
+
+Or install from a working-tree checkout:
+
 ```bash
 make build
 helm install pgagroal helm/pgagroal/ \


### PR DESCRIPTION
## Summary

Publishes the pgAgroal Helm chart as an OCI artifact to GHCR on each release tag — parity with the container image and with Arq-Signals (Elevarq/Arq-Signals#4).

After this, the chart installs by reference without a repo checkout:

```bash
helm install pgagroal oci://ghcr.io/elevarq/charts/pgagroal --version <X.Y.Z>
```

## Changes

- **publish.yml**: new `publish-chart` job (needs `validate` + `publish`) — `helm lint`, package with the version stamped from the release tag (`--version`/`--app-version`), push to `oci://ghcr.io/elevarq/charts`, then cosign-sign the chart digest keyless via the workflow's GitHub OIDC identity (same trust root as the image). Uses the built-in `GITHUB_TOKEN` (`packages: write` already declared) — no new secret.
- **README.md / DOCKER_HUB.md**: document the `oci://` install and `cosign verify`.
- **CHANGELOG.md**: Unreleased entry.

The `validate` job already enforces `Chart.yaml version == tag`, so no version reconcile is needed here — stamping from the tag keeps the published chart aligned regardless.

## Verification

- `actionlint` clean on the workflow.
- `helm lint helm/pgagroal` passes (only the cosmetic icon recommendation).
- `helm package --version 1.2.0 --app-version 1.2.0` produces `pgagroal-1.2.0.tgz` locally.

The publish path itself exercises on the next release tag.

Closes #40