### PR TITLE
security(supply-chain): pin Debian base image by digest (#50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Pin the Debian base image by its multi-arch index digest
+  (`debian:bookworm-20260316-slim@sha256:f065…ab020a`) in both build
+  stages, instead of relying on the mutable dated tag alone. Matches
+  the digest-pinning posture of the arq/workbench images and satisfies
+  Release Protocol Gate D (supply chain). (#50)
+
 ### Added
 
 - Integration stack: `docker-compose.yml` now composes pgagroal +

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,16 @@
 # https://github.com/pgagroal/pgagroal
 
 ARG DEBIAN_VERSION=bookworm-20260316-slim
+# Pin the base by its multi-arch index digest for reproducibility (Gate D).
+# The human-readable tag above is retained for clarity; the digest is
+# authoritative. Keep both in sync — Dependabot/Renovate update them together.
+ARG DEBIAN_DIGEST=sha256:f06537653ac770703bc45b4b113475bd402f451e85223f0f2837acbf89ab020a
 ARG PGAGROAL_VERSION=2.1.0
 
 # =============================================================================
 # Stage 1: Build pgagroal from source
 # =============================================================================
-FROM debian:${DEBIAN_VERSION} AS builder
+FROM debian:${DEBIAN_VERSION}@${DEBIAN_DIGEST} AS builder
 
 ARG PGAGROAL_VERSION
 
@@ -46,7 +50,7 @@ RUN cmake \
 # =============================================================================
 # Stage 2: Minimal runtime image
 # =============================================================================
-FROM debian:${DEBIAN_VERSION}
+FROM debian:${DEBIAN_VERSION}@${DEBIAN_DIGEST}
 
 ARG PGAGROAL_VERSION
 


### PR DESCRIPTION
## Summary

`Dockerfile` pinned the base only by the mutable dated tag `debian:bookworm-20260316-slim`. This pins both build stages to the base's multi-arch **index digest** as well, making the build reproducible and traceable (Release Protocol Gate D), matching the digest-pinning posture of the arq/workbench images.

## Change

- New `ARG DEBIAN_DIGEST=sha256:f06537653ac770703bc45b4b113475bd402f451e85223f0f2837acbf89ab020a`.
- Both `FROM debian:${DEBIAN_VERSION}` lines (builder + runtime) become `FROM debian:${DEBIAN_VERSION}@${DEBIAN_DIGEST}` — the readable tag is retained for clarity, the digest is authoritative.

The digest is the canonical OCI index digest (cross-checked via `docker buildx imagetools inspect` and `RepoDigests`). Dependabot/Renovate update the tag + digest together.

## Validation

- `hadolint Dockerfile` — clean.
- `docker build --check .` — base metadata resolves at the pinned digest; no warnings.

closes #50
