### PR TITLE
security(helm): add optional NetworkPolicy to the chart (#49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Helm chart: optional `NetworkPolicy` (`networkPolicy.enabled`, off by
+  default). When enabled it restricts ingress to operator-listed client
+  pods/namespaces on the pooler (and metrics) port, and egress to just the
+  configured backend Postgres CIDR(s) and DNS — limiting the blast radius
+  of a pooler fronting Postgres. Install NOTES warn when enabled with empty
+  ingress selectors or backend CIDRs. README documents the values. (#49)
+
 ### Added
 
 - Integration stack: `docker-compose.yml` now composes pgagroal +

--- a/README.md
+++ b/README.md
@@ -108,6 +108,34 @@ helm install pgagroal helm/pgagroal/ \
   -n pgagroal --create-namespace
 ```
 
+#### NetworkPolicy (recommended for production)
+
+The pooler fronts your database and is a high-value lateral-movement
+target. The chart ships an opt-in `NetworkPolicy` that restricts ingress
+to the client pods that actually need the pooler and egress to just the
+backend Postgres and DNS. It is **off by default** (not every CNI enforces
+NetworkPolicy, so an always-on manifest would be a silent no-op) — enable
+it explicitly:
+
+```bash
+helm upgrade pgagroal helm/pgagroal/ \
+  --set networkPolicy.enabled=true \
+  --set 'networkPolicy.ingressPodSelectors[0].app\.kubernetes\.io/name=my-app' \
+  --set 'networkPolicy.egress.backendCIDRs[0]=10.0.5.10/32'
+```
+
+| Value | Purpose |
+|---|---|
+| `networkPolicy.enabled` | Render the policy. Recommended `true` in production. |
+| `networkPolicy.ingressPodSelectors` | Label maps of pods allowed to reach the pooler. **Empty = no ingress** (conservative default). |
+| `networkPolicy.ingressNamespaceSelectors` | Label maps of namespaces allowed, in addition to pods. |
+| `networkPolicy.egress.backendCIDRs` | Backend Postgres CIDR(s) (e.g. an RDS `/32`, or the in-cluster pod-network CIDR). Required for a working policy. |
+| `networkPolicy.egress.kubeDNS` | Kube-DNS resolver CIDR(s). |
+
+If you enable the policy with empty ingress selectors or backend CIDRs the
+install NOTES warn you, since the pooler would otherwise be unreachable or
+unable to reach Postgres.
+
 ## Deployment
 
 | Guide | Description |

--- a/helm/pgagroal/templates/NOTES.txt
+++ b/helm/pgagroal/templates/NOTES.txt
@@ -15,3 +15,21 @@ Port-forward for local access:
 
 Prometheus metrics available on port {{ .Values.metrics.port }}.
 {{- end }}
+{{- if .Values.networkPolicy.enabled }}
+
+NetworkPolicy is enabled.
+{{- if not (or .Values.networkPolicy.ingressPodSelectors .Values.networkPolicy.ingressNamespaceSelectors) }}
+  WARNING: no networkPolicy.ingressPodSelectors / ingressNamespaceSelectors
+  are set, so NO pod can reach the pooler. Add the client app's labels.
+{{- end }}
+{{- if not .Values.networkPolicy.egress.backendCIDRs }}
+  WARNING: networkPolicy.egress.backendCIDRs is empty, so the pooler has no
+  egress rule to the backend and cannot reach Postgres. Set the backend
+  CIDR(s) (e.g. an RDS /32 or the in-cluster pod-network CIDR).
+{{- end }}
+{{- else }}
+
+NetworkPolicy is NOT enabled — any in-cluster pod can reach the pooler.
+Set networkPolicy.enabled=true (with ingress selectors + backend CIDRs) to
+restrict access. Recommended for production.
+{{- end }}

--- a/helm/pgagroal/templates/networkpolicy.yaml
+++ b/helm/pgagroal/templates/networkpolicy.yaml
@@ -1,0 +1,80 @@
+{{- /*
+  #49 — NetworkPolicy for the pgagroal pod.
+
+  A connection pooler fronting Postgres is a high-value lateral-movement
+  target. With strong pod/container securityContext but no NetworkPolicy,
+  any in-cluster pod can reach the pooler. This policy restricts:
+
+  - Ingress: only the operator-listed client pods (and/or namespaces) may
+    reach the pooler port (and the metrics port when enabled).
+  - Egress: only the configured backend Postgres CIDR(s) + DNS.
+
+  Opt-in via `networkPolicy.enabled`. Default OFF because not every cluster
+  runs a CNI that enforces NetworkPolicy — in which case the manifest is a
+  silent no-op rather than a security gain. Opt-in surfaces the decision.
+*/}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "pgagroal.fullname" . }}
+  labels:
+    {{- include "pgagroal.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "pgagroal.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    {{- if or .Values.networkPolicy.ingressPodSelectors .Values.networkPolicy.ingressNamespaceSelectors }}
+    - from:
+        {{- range .Values.networkPolicy.ingressPodSelectors }}
+        - podSelector:
+            matchLabels:
+              {{- toYaml . | nindent 14 }}
+        {{- end }}
+        {{- range .Values.networkPolicy.ingressNamespaceSelectors }}
+        - namespaceSelector:
+            matchLabels:
+              {{- toYaml . | nindent 14 }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.pgagroal.port }}
+        {{- if .Values.metrics.enabled }}
+        - protocol: TCP
+          port: {{ .Values.metrics.port }}
+        {{- end }}
+    {{- else }}
+    # No ingress allowed. Operators MUST set
+    # networkPolicy.ingressPodSelectors (the client app's labels) to admit
+    # traffic. Falling through to no-ingress is the conservative default.
+    {{- end }}
+  egress:
+    {{- with .Values.networkPolicy.egress.backendCIDRs }}
+    # Backend Postgres
+    - to:
+        {{- range . }}
+        - ipBlock:
+            cidr: {{ . | quote }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: {{ $.Values.postgresql.port }}
+    {{- end }}
+    {{- with .Values.networkPolicy.egress.kubeDNS }}
+    # DNS
+    - to:
+        {{- range . }}
+        - ipBlock:
+            cidr: {{ . | quote }}
+        {{- end }}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- end }}
+{{- end }}

--- a/helm/pgagroal/values.yaml
+++ b/helm/pgagroal/values.yaml
@@ -72,6 +72,37 @@ service:
   port: 6432
 
 # ---------------------------------------------------------------------------
+# NetworkPolicy (#49). Opt-in. A pooler fronting Postgres is a high-value
+# lateral-movement target; restricting ingress to the pods that actually
+# need the pooler — and egress to just the backend + DNS — limits blast
+# radius. Recommended ON for production.
+#
+# Default OFF because not every cluster runs a CNI that enforces
+# NetworkPolicy (the manifest is then a silent no-op); opt-in surfaces the
+# decision to the operator.
+# ---------------------------------------------------------------------------
+networkPolicy:
+  # -- Render the NetworkPolicy (recommended: true in production)
+  enabled: false
+  # -- Pods allowed to reach the pooler (and metrics) port. Each entry is a
+  # label map. Empty => NO ingress is allowed (conservative default) — list
+  # the client app's labels, e.g.:
+  #   - app.kubernetes.io/name: my-app
+  ingressPodSelectors: []
+  # -- Namespaces allowed to reach the pooler, in addition to pods. Each
+  # entry is a label map matched against namespace labels.
+  ingressNamespaceSelectors: []
+  egress:
+    # -- Backend Postgres CIDR(s) the pooler must reach (e.g. an RDS /32, or
+    # the pod-network CIDR for an in-cluster Postgres). Required for a
+    # working policy: if empty, the backend egress rule is omitted and the
+    # pooler cannot reach Postgres.
+    backendCIDRs: []
+    # -- Kube-DNS resolver CIDR(s). Override per cluster.
+    kubeDNS:
+      - "10.96.0.10/32"
+
+# ---------------------------------------------------------------------------
 # Probes
 # ---------------------------------------------------------------------------
 livenessProbe:


### PR DESCRIPTION
## Summary

A connection pooler fronting Postgres is a high-value lateral-movement target. The chart had strong pod/container `securityContext` but no `NetworkPolicy`, so any in-cluster pod could reach the pooler. This adds an opt-in policy that restricts both ingress and egress.

## Change

New `helm/pgagroal/templates/networkpolicy.yaml`, gated by `networkPolicy.enabled` (default **false** — not every CNI enforces NetworkPolicy, so an always-on manifest would be a silent no-op; opt-in surfaces the decision). When enabled:

- **Ingress** — only the operator-listed `ingressPodSelectors` / `ingressNamespaceSelectors` may reach the pooler port (and the metrics port when `metrics.enabled`). Empty selectors ⇒ no ingress (conservative default).
- **Egress** — only the configured `egress.backendCIDRs` (on the backend port) and `egress.kubeDNS` (53/tcp+udp).

Install NOTES warn when the policy is enabled with empty ingress selectors or empty backend CIDRs (the pooler would be unreachable / unable to reach Postgres). README documents every value and recommends enabling it in production.

## Validation

- `helm lint` — passes.
- `helm template` — default render unchanged (policy gated off); with `networkPolicy.enabled=true` + a pod selector + a backend CIDR it renders ingress restricted to the selector on `6432` and egress to the backend `5432` + DNS (verified output).
- `yamllint` on the rendered policy — clean.
- NOTES warnings verified via `helm install --dry-run` for the empty-selector / empty-backend cases.

(Note: `kube-linter` flags two pre-existing findings on the default render — PDB `unhealthyPodEvictionPolicy` and Deployment anti-affinity — unrelated to this change and present on `main`. kube-linter is a local-only gate, not in CI.)

closes #49
